### PR TITLE
修复tryDecode消息失败陷入无限循环

### DIFF
--- a/handy/conn.cc
+++ b/handy/conn.cc
@@ -255,6 +255,7 @@ void TcpConn::onMsg(CodecBase* codec, const MsgCallBack& cb) {
             r = con->codec_->tryDecode(con->getInput(), msg);
             if (r < 0) {
                 con->channel_->close();
+                break;
             } else if (r > 0) {
                 trace("a msg decoded. origin len %d msg len %ld", r, msg.size());
                 cb(con, msg);


### PR DESCRIPTION
在运行例子example/code-svr.cc时，tryDecode失败后会陷入无限循环，所以增加break语句