### PR TITLE
修改了doc文档的markdown排版

### DIFF
--- a/doc-en.md
+++ b/doc-en.md
@@ -1,4 +1,4 @@
-#handy
+# handy
 yedongfu
 
 A C++11 non-blocking network library
@@ -10,6 +10,7 @@ A C++11 non-blocking network library
 [http server](#http-server)  
 [half sync half async server](#hsha)  
 <h2 id="sample">example--echo</h2>
+
 ```c
 #include <handy/handy.h>
 
@@ -32,42 +33,57 @@ int main(int argc, const char* argv[]) {
 ```
 <h2 id="event-base">EventBase: events dispatcher</h2>
 EventBase is an events dispatcher，use epoll/kqueue to handle non-blocking I/O
+
 ```c
 EventBase base;
 ```
-###events loop
+
+### events loop
+
 ```c
 //call epoll_wait repeatedly, handle I/O events
 base.loop();
 ```
-###exit events loop
+
+### exit events loop
+
 ```c
 //exit events loop, can be called from other threads
 base.exit();
 ```
-###is events loop exited?
+
+### is events loop exited?
+
 ```c
 bool exited();
 ```
-###add tcp connection
+
+### add tcp connection
+
 ```c
 TcpConnPtr con = TcpConn::createConnection(&base, host, port);
 ```
-###add listen fd, and will add all socket return by accept(listen_fd)
+
+### add listen fd, and will add all socket return by accept(listen_fd)
+
 ```c
 TcpServer echo(&base);
 ```
-###perform tasks in I/O thread
+
+### perform tasks in I/O thread
 Some tasks must be called from I/O thread, for example writing some data to connection.
 In order to avoid conflicting read/write, the operation should be performed in a single thread.
+
 ```c
 void safeCall(const Task& task);
 
 base.safeCall([](con){con->send("OK");});
 ```
-###manage timeout tasks
+
+### manage timeout tasks
 EventBase will make itself return by setting a wait time form epoll_wait/kevent.
 It will check and call timeout tasks. The precision rely on epoll_wait/kevent
+
 ```c
 //interval: 0：once task；>0：repeated task, task will be execute every interval milliseconds
 TimerId runAfter(int64_t milli, const Task& task, int64_t interval=0);
@@ -82,15 +98,21 @@ base.cancel(tid);
 
 <h2 id="tcp-conn">TcpConn tcp connection</h2>
 use shared_ptr to manage connection, no need to release manually
-###reference count
+
+### reference count
+
 ```c
 typedef std::shared_ptr<TcpConn> TcpConnPtr;
 ```
-###state
+
+### state
+
 ```c
 enum State { Invalid=1, Handshaking, Connected, Closed, Failed, };
 ```
-###example
+
+### example
+
 ```c
 TcpConnPtr con = TcpConn::createConnection(base, host, port);
 con->onState([=](const TcpConnPtr& con) {
@@ -101,21 +123,28 @@ con->onRead([](const TcpConnPtr& con){
     con->send("ok");
     con->getInput().clear();
 });
+
 ```
-###reconnect setting
+
+### reconnect setting
+
 ```c
 //set reconnect. -1: no reconnect; 0 :reconnect now; other: wait millisecond; default -1
 void setReconnectInterval(int milli);
 ```
-###callback for idle
+
+### callback for idle
+
 ```c
 void addIdleCB(int idle, const TcpCallBack& cb);
 
 //close connection if idle for 30 seconds
 con->addIdleCB(30, [](const TcpConnPtr& con)) { con->close(); });
 ```
-###Message mode
+
+### Message mode
 you can onRead or onMsg to handle message
+
 ```c
 //message callback, confict with onRead callback. You should set only one of these
 //codec will be released when connection destroyed
@@ -127,8 +156,11 @@ con->onMsg(new LineCodec, [](const TcpConnPtr& con, Slice msg) {
     info("recv msg: %.*s", (int)msg.size(), msg.data());
     con->sendMsg("hello");
 });
+
 ```
-###store you own data
+
+### store you own data
+
 ```c
 template<class T> T& context();
 
@@ -136,7 +168,8 @@ con->context<std::string>() = "user defined data";
 ```
 
 <h2 id="tcp-server">TcpServer</h2>
-###example
+### example
+
 ```c
 TcpServer echo(&base);
 int r = echo.bind("", 2099);
@@ -145,8 +178,10 @@ echo.onConnRead([](const TcpConnPtr& con) {
     con->send(con->getInput()); // echo data read
 });
 ```
-###customize your connection
+
+### customize your connection
 when TcpServer accept a connection, it will call this to create an TcpConn
+
 ```
 void onConnCreate(const std::function<TcpConnPtr()>& cb);
 
@@ -162,6 +197,7 @@ chat.onConnCreate([&]{
 ```
 
 <h2 id="http-server">HttpServer</h2>
+
 ```c
 //example
 HttpServer sample(&base);
@@ -172,8 +208,10 @@ sample.onGet("/hello", [](const HttpConnPtr& con) {
    resp.body = Slice("hello world");
    con.sendResponse(resp);
 });
+
 ```
 <h2 id="hsha">half sync half async server</h2>
+
 ```c
 // empty string indicates unfinished handling of request. You may operate on con as you like.
 void onMsg(CodecBase* codec, const RetMsgCallBack& cb);
@@ -184,5 +222,6 @@ hsha.onMsg(new LineCodec, [](const TcpConnPtr& con, const string& input){
     usleep(ms * 1000);
     return util::format("%s used %d ms", input.c_str(), ms);
 });
+
 ```
 updating.......

--- a/doc.md
+++ b/doc.md
@@ -50,13 +50,13 @@ base.loop();
 //退出事件循环，线程安全，可在其他线程中调用
 base.exit();
 ```
-###是否已退出
+### 是否已退出
 
 ```c
 bool exited();
 ```
 
-###在IO线程中执行任务
+### 在IO线程中执行任务
 一些任务必须在IO线程中完成，例如往连接中写入数据。非IO线程需要往连接中写入数据时，必须把任务交由IO线程进行处理
 ```c
 void safeCall(const Task& task);
@@ -64,7 +64,7 @@ void safeCall(const Task& task);
 base.safeCall([con](){con->send("OK");});
 ```
 [例子程序](examples/safe-close.cc)
-###管理定时任务
+### 管理定时任务
 EventBase通过设定epoll_wait/kevent的等待时间让自己及时返回，然后检查是否有到期的任务，因此时间精度依赖于epoll_wait/kevent的精度
 ```c
 //interval: 0：一次性任务；>0：重复任务，每隔interval毫秒，任务被执行一次
@@ -80,24 +80,24 @@ base.cancel(tid);
 [例子程序](examples/timer.cc)
 <h2 id="tcp-conn">TcpConn tcp连接</h2>
 连接采用引用计数的方式进行管理，因此用户无需手动释放连接
-###引用计数
+### 引用计数
 
 ```c
 typedef std::shared_ptr<TcpConn> TcpConnPtr;
 ```
-###状态
+### 状态
 
 ```c
 
 enum State { Invalid=1, Handshaking, Connected, Closed, Failed, };
 ```
 
-###创建连接
+### 创建连接
 
 ```c
 TcpConnPtr con = TcpConn::createConnection(&base, host, port); #第一个参数为前面的EventBase*
 ```
-###使用示例
+### 使用示例
 
 ```c
 TcpConnPtr con = TcpConn::createConnection(&base, host, port);
@@ -112,14 +112,14 @@ con->onRead([](const TcpConnPtr& con){
 ```
 [例子程序](examples/echo.cc)
 
-###设置重连
+### 设置重连
 
 ```c
 //设置重连时间间隔，-1: 不重连，0:立即重连，其它：等待毫秒数，未设置不重连
 void setReconnectInterval(int milli);
 ```
 [例子程序](examples/reconnect.cc)
-###连接空闲回调
+### 连接空闲回调
 
 ```c
 void addIdleCB(int idle, const TcpCallBack& cb);
@@ -129,7 +129,7 @@ con->addIdleCB(30, [](const TcpConnPtr& con)) { con->close(); });
 ```
 [例子程序](examples/idle-close.cc)
 
-###消息模式
+### 消息模式
 可以使用onRead处理消息，也可以选用onMsg方式处理消息
 ```c
 //消息回调，此回调与onRead回调只有一个生效，后设置的生效
@@ -152,11 +152,11 @@ con->context<std::string>() = "user defined data";
 ```
 
 <h2 id="tcp-server">TcpServer tcp服务器</h2>
-###创建tcp服务器
+### 创建tcp服务器
 ```c
 TcpServer echo(&base);
 ```
-###使用示例
+### 使用示例
 ```c
 TcpServer echo(&base); //创建服务器
 int r = echo.bind("", 2099); //绑定端口
@@ -166,7 +166,7 @@ echo.onConnRead([](const TcpConnPtr& con) {
 });
 ```
 [例子程序](examples/echo.cc)
-###自定义创建的连接
+### 自定义创建的连接
 当服务器accept一个连接时，调用此函数
 ```
 void onConnCreate(const std::function<TcpConnPtr()>& cb);

--- a/doc.md
+++ b/doc.md
@@ -38,13 +38,13 @@ EventBase是事件分发器，内部使用epoll/kqueue来管理非阻塞IO
 ```c
 EventBase base;
 ```
-###事件分发循环
+### 事件分发循环
 
 ```c
 //不断调用epoll_wait，处理IO事件
 base.loop();
 ```
-###退出事件循环
+### 退出事件循环
 
 ```c
 //退出事件循环，线程安全，可在其他线程中调用

--- a/doc.md
+++ b/doc.md
@@ -10,7 +10,9 @@ Handy是一个简洁高效的C++11网络库，支持linux与mac平台，使用�
 [http服务器](#http-server)  
 [半同步半异步服务器](#hsha)  
 <h2 id="sample">使用示例--echo</h2>
+
 ```c
+
 #include <handy/handy.h>
 
 using namespace std;

--- a/doc.md
+++ b/doc.md
@@ -58,6 +58,7 @@ bool exited();
 
 ### 在IO线程中执行任务
 一些任务必须在IO线程中完成，例如往连接中写入数据。非IO线程需要往连接中写入数据时，必须把任务交由IO线程进行处理
+
 ```c
 void safeCall(const Task& task);
 
@@ -66,6 +67,7 @@ base.safeCall([con](){con->send("OK");});
 [例子程序](examples/safe-close.cc)
 ### 管理定时任务
 EventBase通过设定epoll_wait/kevent的等待时间让自己及时返回，然后检查是否有到期的任务，因此时间精度依赖于epoll_wait/kevent的精度
+
 ```c
 //interval: 0：一次性任务；>0：重复任务，每隔interval毫秒，任务被执行一次
 TimerId runAfter(int64_t milli, const Task& task, int64_t interval=0);
@@ -131,6 +133,7 @@ con->addIdleCB(30, [](const TcpConnPtr& con)) { con->close(); });
 
 ### 消息模式
 可以使用onRead处理消息，也可以选用onMsg方式处理消息
+
 ```c
 //消息回调，此回调与onRead回调只有一个生效，后设置的生效
 //codec所有权交给onMsg
@@ -144,7 +147,8 @@ con->onMsg(new LineCodec, [](const TcpConnPtr& con, Slice msg) {
 });
 ```
 [例子程序](examples/codec-svr.cc)
-###存放自定义数据
+### 存放自定义数据
+
 ```c
 template<class T> T& context();
 
@@ -153,10 +157,13 @@ con->context<std::string>() = "user defined data";
 
 <h2 id="tcp-server">TcpServer tcp服务器</h2>
 ### 创建tcp服务器
+
 ```c
 TcpServer echo(&base);
 ```
+
 ### 使用示例
+
 ```c
 TcpServer echo(&base); //创建服务器
 int r = echo.bind("", 2099); //绑定端口
@@ -168,6 +175,7 @@ echo.onConnRead([](const TcpConnPtr& con) {
 [例子程序](examples/echo.cc)
 ### 自定义创建的连接
 当服务器accept一个连接时，调用此函数
+
 ```
 void onConnCreate(const std::function<TcpConnPtr()>& cb);
 
@@ -181,9 +189,11 @@ chat.onConnCreate([&]{
     return con;
 });
 ```
+
 [例子程序](examples/codec-svr.cc)
 
 <h2 id="http-server">HttpServer http服务器</h2>
+
 ```c
 //使用示例
 HttpServer sample(&base);
@@ -195,8 +205,10 @@ sample.onGet("/hello", [](const HttpConnPtr& con) {
    con.sendResponse(resp);
 });
 ```
+
 [例子程序](examples/http-hello.cc)
 <h2 id="hsha">半同步半异步服务器</h2>
+
 ```c
 //cb返回空string，表示无需返回数据。如果用户需要更灵活的控制，可以直接操作cb的con参数
 void onMsg(CodecBase* codec, const RetMsgCallBack& cb);
@@ -208,6 +220,7 @@ hsha.onMsg(new LineCodec, [](const TcpConnPtr& con, const string& input){
     return util::format("%s used %d ms", input.c_str(), ms);
 });
 ```
+
 [例子程序](examples/hsha.cc)
 
 持续更新中......

--- a/doc.md
+++ b/doc.md
@@ -156,6 +156,7 @@ con->context<std::string>() = "user defined data";
 ```
 
 <h2 id="tcp-server">TcpServer tcp服务器</h2>
+
 ### 创建tcp服务器
 
 ```c

--- a/doc.md
+++ b/doc.md
@@ -34,23 +34,28 @@ int main(int argc, const char* argv[]) {
 ```
 <h2 id="event-base">EventBase事件分发器</h2>
 EventBase是事件分发器，内部使用epoll/kqueue来管理非阻塞IO
+
 ```c
 EventBase base;
 ```
 ###事件分发循环
+
 ```c
 //不断调用epoll_wait，处理IO事件
 base.loop();
 ```
 ###退出事件循环
+
 ```c
 //退出事件循环，线程安全，可在其他线程中调用
 base.exit();
 ```
 ###是否已退出
+
 ```c
 bool exited();
 ```
+
 ###在IO线程中执行任务
 一些任务必须在IO线程中完成，例如往连接中写入数据。非IO线程需要往连接中写入数据时，必须把任务交由IO线程进行处理
 ```c

--- a/doc.md
+++ b/doc.md
@@ -1,4 +1,4 @@
-#handy
+# handy
 yedongfu
 
 Handy是一个简洁高效的C++11网络库，支持linux与mac平台，使用异步IO模型

--- a/doc.md
+++ b/doc.md
@@ -76,18 +76,24 @@ base.cancel(tid);
 <h2 id="tcp-conn">TcpConn tcp连接</h2>
 连接采用引用计数的方式进行管理，因此用户无需手动释放连接
 ###引用计数
+
 ```c
 typedef std::shared_ptr<TcpConn> TcpConnPtr;
 ```
 ###状态
+
 ```c
+
 enum State { Invalid=1, Handshaking, Connected, Closed, Failed, };
 ```
+
 ###创建连接
+
 ```c
 TcpConnPtr con = TcpConn::createConnection(&base, host, port); #第一个参数为前面的EventBase*
 ```
 ###使用示例
+
 ```c
 TcpConnPtr con = TcpConn::createConnection(&base, host, port);
 con->onState([=](const TcpConnPtr& con) {
@@ -100,13 +106,16 @@ con->onRead([](const TcpConnPtr& con){
 });
 ```
 [例子程序](examples/echo.cc)
+
 ###设置重连
+
 ```c
 //设置重连时间间隔，-1: 不重连，0:立即重连，其它：等待毫秒数，未设置不重连
 void setReconnectInterval(int milli);
 ```
 [例子程序](examples/reconnect.cc)
 ###连接空闲回调
+
 ```c
 void addIdleCB(int idle, const TcpCallBack& cb);
 
@@ -114,6 +123,7 @@ void addIdleCB(int idle, const TcpCallBack& cb);
 con->addIdleCB(30, [](const TcpConnPtr& con)) { con->close(); });
 ```
 [例子程序](examples/idle-close.cc)
+
 ###消息模式
 可以使用onRead处理消息，也可以选用onMsg方式处理消息
 ```c


### PR DESCRIPTION
之前的版本,有几个排版乱掉了.https://github.com/yedf/handy/blob/master/doc.md
主要是修改了两个地方
井号后面加了空格
html代码和```c之间加了回车,

修改后的doc预览如下
https://github.com/sunfishgao/handy/blob/master/doc-en.md
https://github.com/sunfishgao/handy/blob/master/doc.md