### PR TITLE
Fix some lint and make some code more rubust.

### DIFF
--- a/handy/conf.cc
+++ b/handy/conf.cc
@@ -108,9 +108,9 @@ namespace {
     };
 }
 
-int Conf::parse(const string& filename1) {
-    filename = filename1;
-    FILE* file = fopen(filename.c_str(), "r");
+int Conf::parse(const string& filename) {
+    this->filename = filename;
+    FILE* file = fopen(this->filename.c_str(), "r");
     if (!file)
         return -1;
     unique_ptr<FILE, decltype(fclose)*> release2(file, fclose);

--- a/handy/conf.h
+++ b/handy/conf.h
@@ -10,7 +10,7 @@ struct Conf {
     // 0 success
     // -1 IOERROR
     // >0 line no of error
-    int parse(const std::string& filename1);
+    int parse(const std::string& filename);
 
     // Get a string value from INI file, returning default_value if not found.
     std::string get(std::string section, std::string name, std::string default_value);

--- a/handy/util.h
+++ b/handy/util.h
@@ -9,7 +9,10 @@
 namespace handy {
 
 struct noncopyable {
-    noncopyable() {};
+protected:
+    noncopyable() = default;
+    virtual ~noncopyable() = default;
+
     noncopyable(const noncopyable&) = delete;
     noncopyable& operator=(const noncopyable&) = delete;
 };


### PR DESCRIPTION
In this change, I have done 2 tiny things:

1. Changed a parameter name in `Conf` because we shouldn't use `1, 2, 3...` and any characters without meaning for variables to distinguish from some other words.

2. Made `noncopyable` more rubust. 
