### PR TITLE
Format code by clang-format tool and enable in CI.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: Chromium
+ColumnLimit: 160
+IndentWidth: 4
+DerivePointerAlignment: false
+IndentCaseLabels: false
+PointerAlignment: Right
+SpaceAfterCStyleCast: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,30 @@
+sudo: required
+
 language: cpp
 compiler: g++
-before_install:
-    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-    - sudo apt-get update -qq
-install:
-    - sudo apt-get install -qq g++-4.8
-    - export CXX="g++-4.8"
-script: make && sudo ./handy_test
-notifications:
-    email: true
 
+matrix:
+    include:
+        # Job1: This is the job of building project in linux os.
+      - os: linux
+        dist: trusty
+        before_install:
+            - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            - sudo apt-get update -qq
+        install:
+            - sudo apt-get install -qq g++-4.8
+            - export CXX="g++-4.8"
+        script: make && sudo ./handy_test
+        notifications:
+            email: true
+
+        # Job2: This is the job of checking code style.
+      - os: linux
+        dist: trusty
+        env: LINT=1 PYTHON=2.7
+        before_install:
+          - sudo apt-get update -qq
+          - sudo apt-get install -qq clang-format-3.8
+        install: []
+        script:
+          - sudo bash .travis/check-git-clang-format.sh

--- a/.travis/check-git-clang-format.sh
+++ b/.travis/check-git-clang-format.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ "$TRAVIS_PULL_REQUEST" == "true" ] ; then
+    base_commit="$TRAVIS_BRANCH"
+else
+    base_commit="HEAD^"
+fi
+
+output="$(sudo python .travis/git-clang-format --binary clang-format-3.8 --commit $base_commit --diff)"
+
+if [ "$output" == "no modified files to format" ] || [ "$output" == "clang-format did not modify any files" ] ; then
+    echo "clang-format passed."
+    exit 0
+else
+    echo "clang-format failed."
+    echo "$output"
+    exit 1
+fi

--- a/.travis/git-clang-format
+++ b/.travis/git-clang-format
@@ -1,0 +1,490 @@
+#!/usr/bin/env python
+#
+#===- git-clang-format - ClangFormat Git Integration ---------*- python -*--===#
+#
+#                     The LLVM Compiler Infrastructure
+#
+# This file is distributed under the University of Illinois Open Source
+# License. See LICENSE.TXT for details.
+#
+#===------------------------------------------------------------------------===#
+
+r"""
+clang-format git integration
+============================
+
+This file provides a clang-format integration for git. Put it somewhere in your
+path and ensure that it is executable. Then, "git clang-format" will invoke
+clang-format on the changes in current files or a specific commit.
+
+For further details, run:
+git clang-format -h
+
+Requires Python 2.7
+"""
+
+import argparse
+import collections
+import contextlib
+import errno
+import os
+import re
+import subprocess
+import sys
+
+usage = 'git clang-format [OPTIONS] [<commit>] [--] [<file>...]'
+
+desc = '''
+Run clang-format on all lines that differ between the working directory
+and <commit>, which defaults to HEAD.  Changes are only applied to the working
+directory.
+
+The following git-config settings set the default of the corresponding option:
+  clangFormat.binary
+  clangFormat.commit
+  clangFormat.extension
+  clangFormat.style
+'''
+
+# Name of the temporary index file in which save the output of clang-format.
+# This file is created within the .git directory.
+temp_index_basename = 'clang-format-index'
+
+
+Range = collections.namedtuple('Range', 'start, count')
+
+
+def main():
+  config = load_git_config()
+
+  # In order to keep '--' yet allow options after positionals, we need to
+  # check for '--' ourselves.  (Setting nargs='*' throws away the '--', while
+  # nargs=argparse.REMAINDER disallows options after positionals.)
+  argv = sys.argv[1:]
+  try:
+    idx = argv.index('--')
+  except ValueError:
+    dash_dash = []
+  else:
+    dash_dash = argv[idx:]
+    argv = argv[:idx]
+
+  default_extensions = ','.join([
+      # From clang/lib/Frontend/FrontendOptions.cpp, all lower case
+      'c', 'h',  # C
+      'm',  # ObjC
+      'mm',  # ObjC++
+      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hpp',  # C++
+      # Other languages that clang-format supports
+      'proto', 'protodevel',  # Protocol Buffers
+      'js',  # JavaScript
+      'ts',  # TypeScript
+      ])
+
+  p = argparse.ArgumentParser(
+    usage=usage, formatter_class=argparse.RawDescriptionHelpFormatter,
+    description=desc)
+  p.add_argument('--binary',
+                 default=config.get('clangformat.binary', 'clang-format'),
+                 help='path to clang-format'),
+  p.add_argument('--commit',
+                 default=config.get('clangformat.commit', 'HEAD'),
+                 help='default commit to use if none is specified'),
+  p.add_argument('--diff', action='store_true',
+                 help='print a diff instead of applying the changes')
+  p.add_argument('--extensions',
+                 default=config.get('clangformat.extensions',
+                                    default_extensions),
+                 help=('comma-separated list of file extensions to format, '
+                       'excluding the period and case-insensitive')),
+  p.add_argument('--exclude', help='Exclude files matching this regex.')
+  p.add_argument('-f', '--force', action='store_true',
+                 help='allow changes to unstaged files')
+  p.add_argument('-p', '--patch', action='store_true',
+                 help='select hunks interactively')
+  p.add_argument('-q', '--quiet', action='count', default=0,
+                 help='print less information')
+  p.add_argument('--style',
+                 default=config.get('clangformat.style', None),
+                 help='passed to clang-format'),
+  p.add_argument('-v', '--verbose', action='count', default=0,
+                 help='print extra information')
+  # We gather all the remaining positional arguments into 'args' since we need
+  # to use some heuristics to determine whether or not <commit> was present.
+  # However, to print pretty messages, we make use of metavar and help.
+  p.add_argument('args', nargs='*', metavar='<commit>',
+                 help='revision from which to compute the diff')
+  p.add_argument('ignored', nargs='*', metavar='<file>...',
+                 help='if specified, only consider differences in these files')
+  opts = p.parse_args(argv)
+
+  opts.verbose -= opts.quiet
+  del opts.quiet
+
+  commit, files = interpret_args(opts.args, dash_dash, opts.commit)
+  changed_lines = compute_diff_and_extract_lines(commit, files)
+  if opts.verbose >= 1:
+    ignored_files = set(changed_lines)
+  filter_by_extension(changed_lines, opts.extensions.lower().split(','))
+  if opts.exclude:
+    for filename in changed_lines.keys():
+      if re.match(opts.exclude, filename):
+        del changed_lines[filename]
+  if opts.verbose >= 1:
+    ignored_files.difference_update(changed_lines)
+    if ignored_files:
+      print 'Ignoring changes in the following files:'
+      for filename in ignored_files:
+        print '   ', filename
+    if changed_lines:
+      print 'Running clang-format on the following files:'
+      for filename in changed_lines:
+        print '   ', filename
+  if not changed_lines:
+    print 'no modified files to format'
+    return
+  # The computed diff outputs absolute paths, so we must cd before accessing
+  # those files.
+  cd_to_toplevel()
+  old_tree = create_tree_from_workdir(changed_lines)
+  new_tree = run_clang_format_and_save_to_tree(changed_lines,
+                                               binary=opts.binary,
+                                               style=opts.style)
+  if opts.verbose >= 1:
+    print 'old tree:', old_tree
+    print 'new tree:', new_tree
+  if old_tree == new_tree:
+    if opts.verbose >= 0:
+      print 'clang-format did not modify any files'
+  elif opts.diff:
+    print_diff(old_tree, new_tree)
+  else:
+    changed_files = apply_changes(old_tree, new_tree, force=opts.force,
+                                  patch_mode=opts.patch)
+    if (opts.verbose >= 0 and not opts.patch) or opts.verbose >= 1:
+      print 'changed files:'
+      for filename in changed_files:
+        print '   ', filename
+
+
+def load_git_config(non_string_options=None):
+  """Return the git configuration as a dictionary.
+
+  All options are assumed to be strings unless in `non_string_options`, in which
+  is a dictionary mapping option name (in lower case) to either "--bool" or
+  "--int"."""
+  if non_string_options is None:
+    non_string_options = {}
+  out = {}
+  for entry in run('git', 'config', '--list', '--null').split('\0'):
+    if entry:
+      name, value = entry.split('\n', 1)
+      if name in non_string_options:
+        value = run('git', 'config', non_string_options[name], name)
+      out[name] = value
+  return out
+
+
+def interpret_args(args, dash_dash, default_commit):
+  """Interpret `args` as "[commit] [--] [files...]" and return (commit, files).
+
+  It is assumed that "--" and everything that follows has been removed from
+  args and placed in `dash_dash`.
+
+  If "--" is present (i.e., `dash_dash` is non-empty), the argument to its
+  left (if present) is taken as commit.  Otherwise, the first argument is
+  checked if it is a commit or a file.  If commit is not given,
+  `default_commit` is used."""
+  if dash_dash:
+    if len(args) == 0:
+      commit = default_commit
+    elif len(args) > 1:
+      die('at most one commit allowed; %d given' % len(args))
+    else:
+      commit = args[0]
+    object_type = get_object_type(commit)
+    if object_type not in ('commit', 'tag'):
+      if object_type is None:
+        die("'%s' is not a commit" % commit)
+      else:
+        die("'%s' is a %s, but a commit was expected" % (commit, object_type))
+    files = dash_dash[1:]
+  elif args:
+    if disambiguate_revision(args[0]):
+      commit = args[0]
+      files = args[1:]
+    else:
+      commit = default_commit
+      files = args
+  else:
+    commit = default_commit
+    files = []
+  return commit, files
+
+
+def disambiguate_revision(value):
+  """Returns True if `value` is a revision, False if it is a file, or dies."""
+  # If `value` is ambiguous (neither a commit nor a file), the following
+  # command will die with an appropriate error message.
+  run('git', 'rev-parse', value, verbose=False)
+  object_type = get_object_type(value)
+  if object_type is None:
+    return False
+  if object_type in ('commit', 'tag'):
+    return True
+  die('`%s` is a %s, but a commit or filename was expected' %
+      (value, object_type))
+
+
+def get_object_type(value):
+  """Returns a string description of an object's type, or None if it is not
+  a valid git object."""
+  cmd = ['git', 'cat-file', '-t', value]
+  p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  stdout, stderr = p.communicate()
+  if p.returncode != 0:
+    return None
+  return stdout.strip()
+
+
+def compute_diff_and_extract_lines(commit, files):
+  """Calls compute_diff() followed by extract_lines()."""
+  diff_process = compute_diff(commit, files)
+  changed_lines = extract_lines(diff_process.stdout)
+  diff_process.stdout.close()
+  diff_process.wait()
+  if diff_process.returncode != 0:
+    # Assume error was already printed to stderr.
+    sys.exit(2)
+  return changed_lines
+
+
+def compute_diff(commit, files):
+  """Return a subprocess object producing the diff from `commit`.
+
+  The return value's `stdin` file object will produce a patch with the
+  differences between the working directory and `commit`, filtered on `files`
+  (if non-empty).  Zero context lines are used in the patch."""
+  cmd = ['git', 'diff-index', '-p', '-U0', commit, '--']
+  cmd.extend(files)
+  p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+  p.stdin.close()
+  return p
+
+
+def extract_lines(patch_file):
+  """Extract the changed lines in `patch_file`.
+
+  The return value is a dictionary mapping filename to a list of (start_line,
+  line_count) pairs.
+
+  The input must have been produced with ``-U0``, meaning unidiff format with
+  zero lines of context.  The return value is a dict mapping filename to a
+  list of line `Range`s."""
+  matches = {}
+  for line in patch_file:
+    match = re.search(r'^\+\+\+\ [^/]+/(.*)', line)
+    if match:
+      filename = match.group(1).rstrip('\r\n')
+    match = re.search(r'^@@ -[0-9,]+ \+(\d+)(,(\d+))?', line)
+    if match:
+      start_line = int(match.group(1))
+      line_count = 1
+      if match.group(3):
+        line_count = int(match.group(3))
+      if line_count > 0:
+        matches.setdefault(filename, []).append(Range(start_line, line_count))
+  return matches
+
+
+def filter_by_extension(dictionary, allowed_extensions):
+  """Delete every key in `dictionary` that doesn't have an allowed extension.
+
+  `allowed_extensions` must be a collection of lowercase file extensions,
+  excluding the period."""
+  allowed_extensions = frozenset(allowed_extensions)
+  for filename in dictionary.keys():
+    base_ext = filename.rsplit('.', 1)
+    if len(base_ext) == 1 or base_ext[1].lower() not in allowed_extensions:
+      del dictionary[filename]
+
+
+def cd_to_toplevel():
+  """Change to the top level of the git repository."""
+  toplevel = run('git', 'rev-parse', '--show-toplevel')
+  os.chdir(toplevel)
+
+
+def create_tree_from_workdir(filenames):
+  """Create a new git tree with the given files from the working directory.
+
+  Returns the object ID (SHA-1) of the created tree."""
+  return create_tree(filenames, '--stdin')
+
+
+def run_clang_format_and_save_to_tree(changed_lines, binary='clang-format',
+                                      style=None):
+  """Run clang-format on each file and save the result to a git tree.
+
+  Returns the object ID (SHA-1) of the created tree."""
+  def index_info_generator():
+    for filename, line_ranges in changed_lines.iteritems():
+      mode = oct(os.stat(filename).st_mode)
+      blob_id = clang_format_to_blob(filename, line_ranges, binary=binary,
+                                     style=style)
+      yield '%s %s\t%s' % (mode, blob_id, filename)
+  return create_tree(index_info_generator(), '--index-info')
+
+
+def create_tree(input_lines, mode):
+  """Create a tree object from the given input.
+
+  If mode is '--stdin', it must be a list of filenames.  If mode is
+  '--index-info' is must be a list of values suitable for "git update-index
+  --index-info", such as "<mode> <SP> <sha1> <TAB> <filename>".  Any other mode
+  is invalid."""
+  assert mode in ('--stdin', '--index-info')
+  cmd = ['git', 'update-index', '--add', '-z', mode]
+  with temporary_index_file():
+    p = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    for line in input_lines:
+      p.stdin.write('%s\0' % line)
+    p.stdin.close()
+    if p.wait() != 0:
+      die('`%s` failed' % ' '.join(cmd))
+    tree_id = run('git', 'write-tree')
+    return tree_id
+
+
+def clang_format_to_blob(filename, line_ranges, binary='clang-format',
+                         style=None):
+  """Run clang-format on the given file and save the result to a git blob.
+
+  Returns the object ID (SHA-1) of the created blob."""
+  clang_format_cmd = [binary, filename]
+  if style:
+    clang_format_cmd.extend(['-style='+style])
+  clang_format_cmd.extend([
+      '-lines=%s:%s' % (start_line, start_line+line_count-1)
+      for start_line, line_count in line_ranges])
+  try:
+    clang_format = subprocess.Popen(clang_format_cmd, stdin=subprocess.PIPE,
+                                    stdout=subprocess.PIPE)
+  except OSError as e:
+    if e.errno == errno.ENOENT:
+      die('cannot find executable "%s"' % binary)
+    else:
+      raise
+  clang_format.stdin.close()
+  hash_object_cmd = ['git', 'hash-object', '-w', '--path='+filename, '--stdin']
+  hash_object = subprocess.Popen(hash_object_cmd, stdin=clang_format.stdout,
+                                 stdout=subprocess.PIPE)
+  clang_format.stdout.close()
+  stdout = hash_object.communicate()[0]
+  if hash_object.returncode != 0:
+    die('`%s` failed' % ' '.join(hash_object_cmd))
+  if clang_format.wait() != 0:
+    die('`%s` failed' % ' '.join(clang_format_cmd))
+  return stdout.rstrip('\r\n')
+
+
+@contextlib.contextmanager
+def temporary_index_file(tree=None):
+  """Context manager for setting GIT_INDEX_FILE to a temporary file and deleting
+  the file afterward."""
+  index_path = create_temporary_index(tree)
+  old_index_path = os.environ.get('GIT_INDEX_FILE')
+  os.environ['GIT_INDEX_FILE'] = index_path
+  try:
+    yield
+  finally:
+    if old_index_path is None:
+      del os.environ['GIT_INDEX_FILE']
+    else:
+      os.environ['GIT_INDEX_FILE'] = old_index_path
+    os.remove(index_path)
+
+
+def create_temporary_index(tree=None):
+  """Create a temporary index file and return the created file's path.
+
+  If `tree` is not None, use that as the tree to read in.  Otherwise, an
+  empty index is created."""
+  gitdir = run('git', 'rev-parse', '--git-dir')
+  path = os.path.join(gitdir, temp_index_basename)
+  if tree is None:
+    tree = '--empty'
+  run('git', 'read-tree', '--index-output='+path, tree)
+  return path
+
+
+def print_diff(old_tree, new_tree):
+  """Print the diff between the two trees to stdout."""
+  # We use the porcelain 'diff' and not plumbing 'diff-tree' because the output
+  # is expected to be viewed by the user, and only the former does nice things
+  # like color and pagination.
+  subprocess.check_call(['git', 'diff', old_tree, new_tree, '--'])
+
+
+def apply_changes(old_tree, new_tree, force=False, patch_mode=False):
+  """Apply the changes in `new_tree` to the working directory.
+
+  Bails if there are local changes in those files and not `force`.  If
+  `patch_mode`, runs `git checkout --patch` to select hunks interactively."""
+  changed_files = run('git', 'diff-tree', '-r', '-z', '--name-only', old_tree,
+                      new_tree).rstrip('\0').split('\0')
+  if not force:
+    unstaged_files = run('git', 'diff-files', '--name-status', *changed_files)
+    if unstaged_files:
+      print >>sys.stderr, ('The following files would be modified but '
+                           'have unstaged changes:')
+      print >>sys.stderr, unstaged_files
+      print >>sys.stderr, 'Please commit, stage, or stash them first.'
+      sys.exit(2)
+  if patch_mode:
+    # In patch mode, we could just as well create an index from the new tree
+    # and checkout from that, but then the user will be presented with a
+    # message saying "Discard ... from worktree".  Instead, we use the old
+    # tree as the index and checkout from new_tree, which gives the slightly
+    # better message, "Apply ... to index and worktree".  This is not quite
+    # right, since it won't be applied to the user's index, but oh well.
+    with temporary_index_file(old_tree):
+      subprocess.check_call(['git', 'checkout', '--patch', new_tree])
+    index_tree = old_tree
+  else:
+    with temporary_index_file(new_tree):
+      run('git', 'checkout-index', '-a', '-f')
+  return changed_files
+
+
+def run(*args, **kwargs):
+  stdin = kwargs.pop('stdin', '')
+  verbose = kwargs.pop('verbose', True)
+  strip = kwargs.pop('strip', True)
+  for name in kwargs:
+    raise TypeError("run() got an unexpected keyword argument '%s'" % name)
+  p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                       stdin=subprocess.PIPE)
+  stdout, stderr = p.communicate(input=stdin)
+  if p.returncode == 0:
+    if stderr:
+      if verbose:
+        print >>sys.stderr, '`%s` printed to stderr:' % ' '.join(args)
+      print >>sys.stderr, stderr.rstrip()
+    if strip:
+      stdout = stdout.rstrip('\r\n')
+    return stdout
+  if verbose:
+    print >>sys.stderr, '`%s` returned %s' % (' '.join(args), p.returncode)
+  if stderr:
+    print >>sys.stderr, stderr.rstrip()
+  sys.exit(2)
+
+
+def die(message):
+  print >>sys.stderr, 'error:', message
+  sys.exit(2)
+
+
+if __name__ == '__main__':
+  main()

--- a/10m/10m-cli.cc
+++ b/10m/10m-cli.cc
@@ -12,9 +12,10 @@ struct Report {
     Report() { memset(this, 0, sizeof(*this)); }
 };
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     if (argc < 9) {
-        printf("usage %s <host> <begin port> <end port> <conn count> <create seconds> <subprocesses> <hearbeat interval> <send size> <management port>\n", argv[0]);
+        printf("usage %s <host> <begin port> <end port> <conn count> <create seconds> <subprocesses> <hearbeat interval> <send size> <management port>\n",
+               argv[0]);
         return 1;
     }
     int c = 1;
@@ -30,18 +31,18 @@ int main(int argc, const char* argv[]) {
     int man_port = atoi(argv[c++]);
 
     int pid = 1;
-    for (int i = 0; i < processes; i ++) {
+    for (int i = 0; i < processes; i++) {
         pid = fork();
-        if (pid == 0) { // a child process, break
+        if (pid == 0) {  // a child process, break
             sleep(1);
             break;
         }
     }
-    Signal::signal(SIGPIPE, []{});
+    Signal::signal(SIGPIPE, [] {});
     EventBase base;
-    if (pid == 0) { //child process
+    if (pid == 0) {  // child process
         char *buf = new char[bsz];
-        ExitCaller ec1([=] {delete[] buf; });
+        ExitCaller ec1([=] { delete[] buf; });
         Slice msg(buf, bsz);
         char heartbeat[] = "heartbeat";
         int send = 0;
@@ -51,94 +52,98 @@ int main(int argc, const char* argv[]) {
 
         vector<TcpConnPtr> allConns;
         info("creating %d connections", conn_count);
-        for (int k = 0; k < create_seconds * 10; k ++) {
-            base.runAfter(100*k, [&]{
+        for (int k = 0; k < create_seconds * 10; k++) {
+            base.runAfter(100 * k, [&] {
                 int c = conn_count / create_seconds / 10;
                 for (int i = 0; i < c; i++) {
                     short port = begin_port + (i % (end_port - begin_port));
-                    auto con = TcpConn::createConnection(&base, host, port, 20*1000);
+                    auto con = TcpConn::createConnection(&base, host, port, 20 * 1000);
                     allConns.push_back(con);
-                    con->setReconnectInterval(20*1000);
-                    con->onMsg(new LengthCodec, [&](const TcpConnPtr& con, const Slice& msg) {
-                        if (heartbeat_interval == 0) { // echo the msg if no interval
+                    con->setReconnectInterval(20 * 1000);
+                    con->onMsg(new LengthCodec, [&](const TcpConnPtr &con, const Slice &msg) {
+                        if (heartbeat_interval == 0) {  // echo the msg if no interval
                             con->sendMsg(msg);
                             send++;
                         }
-                        recved ++;
+                        recved++;
                     });
                     con->onState([&, i](const TcpConnPtr &con) {
                         TcpConn::State st = con->getState();
                         if (st == TcpConn::Connected) {
                             connected++;
-//                            send ++;
-//                            con->sendMsg(msg);
-                        } else if (st == TcpConn::Failed || st == TcpConn::Closed) { //连接出错
-                            if (st == TcpConn::Closed) { connected--; }
+                            //                            send ++;
+                            //                            con->sendMsg(msg);
+                        } else if (st == TcpConn::Failed || st == TcpConn::Closed) {  //连接出错
+                            if (st == TcpConn::Closed) {
+                                connected--;
+                            }
                             retry++;
                         }
                     });
                 }
-
             });
         }
         if (heartbeat_interval) {
-            base.runAfter(heartbeat_interval * 1000, [&] {
-                for (int i = 0; i < heartbeat_interval*10; i ++) {
-                    base.runAfter(i*100, [&,i]{
-                        size_t block = allConns.size() / heartbeat_interval / 10;
-                        for (size_t j=i*block; j<(i+1)*block && j<allConns.size(); j++) {
-                            if (allConns[j]->getState() == TcpConn::Connected) {
-                                allConns[j]->sendMsg(msg);
-                                send++;
-                            }
-                        }
-                    });
-                }
-            }, heartbeat_interval * 1000);
+            base.runAfter(heartbeat_interval * 1000,
+                          [&] {
+                              for (int i = 0; i < heartbeat_interval * 10; i++) {
+                                  base.runAfter(i * 100, [&, i] {
+                                      size_t block = allConns.size() / heartbeat_interval / 10;
+                                      for (size_t j = i * block; j < (i + 1) * block && j < allConns.size(); j++) {
+                                          if (allConns[j]->getState() == TcpConn::Connected) {
+                                              allConns[j]->sendMsg(msg);
+                                              send++;
+                                          }
+                                      }
+                                  });
+                              }
+                          },
+                          heartbeat_interval * 1000);
         }
         TcpConnPtr report = TcpConn::createConnection(&base, "127.0.0.1", man_port, 3000);
-        report->onMsg(new LineCodec, [&](const TcpConnPtr& con, Slice msg) {
+        report->onMsg(new LineCodec, [&](const TcpConnPtr &con, Slice msg) {
             if (msg == "exit") {
                 info("recv exit msg from master, so exit");
                 base.exit();
             }
         });
-        report->onState([&](const TcpConnPtr& con) {
+        report->onState([&](const TcpConnPtr &con) {
             if (con->getState() == TcpConn::Closed) {
                 base.exit();
             }
         });
-        base.runAfter(2000, [&]() {
-            report->sendMsg(util::format("%d connected: %ld retry: %ld send: %ld recved: %ld",
-                                         getpid(), connected, retry, send, recved));
-        }, 100);
+        base.runAfter(2000,
+                      [&]() { report->sendMsg(util::format("%d connected: %ld retry: %ld send: %ld recved: %ld", getpid(), connected, retry, send, recved)); },
+                      100);
         base.loop();
-    } else { // master process
+    } else {  // master process
         map<int, Report> subs;
         TcpServerPtr master = TcpServer::startServer(&base, "127.0.0.1", man_port);
-        master->onConnMsg(new LineCodec, [&](const TcpConnPtr& con, Slice msg) {
+        master->onConnMsg(new LineCodec, [&](const TcpConnPtr &con, Slice msg) {
             auto fs = msg.split(' ');
             if (fs.size() != 9) {
                 error("number of fields is %lu expected 7", fs.size());
                 return;
             }
-            Report& c = subs[atoi(fs[0].data())];
+            Report &c = subs[atoi(fs[0].data())];
             c.connected = atoi(fs[2].data());
-            c.retry= atoi(fs[4].data());
+            c.retry = atoi(fs[4].data());
             c.sended = atoi(fs[6].data());
             c.recved = atoi(fs[8].data());
         });
-        base.runAfter(3000, [&](){
-            for(auto& s: subs) {
-                Report& r = s.second;
-                printf("pid: %6ld connected %6ld retry %6ld sended %6ld recved %6ld\n", (long)s.first, r.connected, r.retry, r.sended, r.recved);
-            }
-            printf("\n");
-        }, 3000);
-        Signal::signal(SIGCHLD, []{
+        base.runAfter(3000,
+                      [&]() {
+                          for (auto &s : subs) {
+                              Report &r = s.second;
+                              printf("pid: %6ld connected %6ld retry %6ld sended %6ld recved %6ld\n", (long) s.first, r.connected, r.retry, r.sended, r.recved);
+                          }
+                          printf("\n");
+                      },
+                      3000);
+        Signal::signal(SIGCHLD, [] {
             int status = 0;
             wait(&status);
-            error("wait result: status: %d is signaled: %d signal: %d", status,  WIFSIGNALED(status), WTERMSIG(status));
+            error("wait result: status: %d is signaled: %d signal: %d", status, WIFSIGNALED(status), WTERMSIG(status));
         });
         base.loop();
     }

--- a/10m/10m-svr.cc
+++ b/10m/10m-svr.cc
@@ -10,7 +10,7 @@ struct Report {
     Report() { memset(this, 0, sizeof(*this)); }
 };
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     if (argc < 5) {
         printf("usage: %s <begin port> <end port> <subprocesses> <management port>\n", argv[0]);
         return 1;
@@ -20,32 +20,32 @@ int main(int argc, const char* argv[]) {
     int processes = atoi(argv[3]);
     int man_port = atoi(argv[4]);
     int pid = 1;
-    for (int i = 0; i < processes; i ++) {
+    for (int i = 0; i < processes; i++) {
         pid = fork();
-        if (pid == 0) { // a child process, break
+        if (pid == 0) {  // a child process, break
             break;
         }
     }
     EventBase base;
-    if (pid == 0) { //child process
-        usleep(100*1000); // wait master to listen management port
+    if (pid == 0) {          // child process
+        usleep(100 * 1000);  // wait master to listen management port
         vector<TcpServerPtr> svrs;
         long connected = 0, closed = 0, recved = 0;
-        for (int i = 0; i < end_port-begin_port; i ++) {
+        for (int i = 0; i < end_port - begin_port; i++) {
             TcpServerPtr p = TcpServer::startServer(&base, "", begin_port + i, true);
-            p->onConnCreate([&]{
+            p->onConnCreate([&] {
                 TcpConnPtr con(new TcpConn);
-                con->onState([&](const TcpConnPtr& con) {
+                con->onState([&](const TcpConnPtr &con) {
                     auto st = con->getState();
                     if (st == TcpConn::Connected) {
-                        connected ++;
+                        connected++;
                     } else if (st == TcpConn::Closed || st == TcpConn::Failed) {
-                        closed ++;
-                        connected --;
+                        closed++;
+                        connected--;
                     }
                 });
-                con->onMsg(new LengthCodec, [&](const TcpConnPtr& con, Slice msg) {
-                    recved ++;
+                con->onMsg(new LengthCodec, [&](const TcpConnPtr &con, Slice msg) {
+                    recved++;
                     con->sendMsg(msg);
                 });
                 return con;
@@ -53,42 +53,42 @@ int main(int argc, const char* argv[]) {
             svrs.push_back(p);
         }
         TcpConnPtr report = TcpConn::createConnection(&base, "127.0.0.1", man_port, 3000);
-        report->onMsg(new LineCodec, [&](const TcpConnPtr& con, Slice msg) {
+        report->onMsg(new LineCodec, [&](const TcpConnPtr &con, Slice msg) {
             if (msg == "exit") {
                 info("recv exit msg from master, so exit");
                 base.exit();
             }
         });
-        report->onState([&](const TcpConnPtr& con) {
+        report->onState([&](const TcpConnPtr &con) {
             if (con->getState() == TcpConn::Closed) {
                 base.exit();
             }
         });
-        base.runAfter(100, [&]() {
-            report->sendMsg(util::format("%d connected: %ld closed: %ld recved: %ld", getpid(), connected, closed, recved));
-        }, 100);
+        base.runAfter(100, [&]() { report->sendMsg(util::format("%d connected: %ld closed: %ld recved: %ld", getpid(), connected, closed, recved)); }, 100);
         base.loop();
     } else {
         map<int, Report> subs;
         TcpServerPtr master = TcpServer::startServer(&base, "127.0.0.1", man_port);
-        master->onConnMsg(new LineCodec, [&](const TcpConnPtr& con, Slice msg) {
+        master->onConnMsg(new LineCodec, [&](const TcpConnPtr &con, Slice msg) {
             auto fs = msg.split(' ');
             if (fs.size() != 7) {
                 error("number of fields is %lu expected 7", fs.size());
                 return;
             }
-            Report& c = subs[atoi(fs[0].data())];
+            Report &c = subs[atoi(fs[0].data())];
             c.connected = atoi(fs[2].data());
             c.closed = atoi(fs[4].data());
             c.recved = atoi(fs[6].data());
         });
-        base.runAfter(3000, [&](){
-            for(auto& s: subs) {
-                Report r = s.second;
-                printf("pid: %6d connected %6ld closed: %6ld recved %6ld\n", s.first, r.connected, r.closed, r.recved);
-            }
-            printf("\n");
-        }, 3000);
+        base.runAfter(3000,
+                      [&]() {
+                          for (auto &s : subs) {
+                              Report r = s.second;
+                              printf("pid: %6d connected %6ld closed: %6ld recved %6ld\n", s.first, r.connected, r.closed, r.recved);
+                          }
+                          printf("\n");
+                      },
+                      3000);
         base.loop();
     }
     info("program exited");

--- a/examples/chat.cc
+++ b/examples/chat.cc
@@ -4,50 +4,50 @@
 using namespace std;
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     setloglevel("TRACE");
-    map<intptr_t, TcpConnPtr> users; //生命周期比连接更长，必须放在Base前
+    map<intptr_t, TcpConnPtr> users;  //生命周期比连接更长，必须放在Base前
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
 
     int userid = 1;
     TcpServerPtr chat = TcpServer::startServer(&base, "", 2099);
     exitif(chat == NULL, "start tcpserver failed");
-    chat->onConnCreate([&]{
+    chat->onConnCreate([&] {
         TcpConnPtr con(new TcpConn);
-        con->onState([&](const TcpConnPtr& con) {
+        con->onState([&](const TcpConnPtr &con) {
             if (con->getState() == TcpConn::Connected) {
                 con->context<int>() = userid;
-                const char* welcome = "<id> <msg>: send msg to <id>\n<msg>: send msg to all\n\nhello %d";
+                const char *welcome = "<id> <msg>: send msg to <id>\n<msg>: send msg to all\n\nhello %d";
                 con->sendMsg(util::format(welcome, userid));
                 users[userid] = con;
-                userid ++;
+                userid++;
             } else if (con->getState() == TcpConn::Closed) {
                 users.erase(con->context<int>());
             }
         });
-        con->onMsg(new LineCodec, [&](const TcpConnPtr& con, Slice msg){
-            if (msg.size() == 0) { //忽略空消息
+        con->onMsg(new LineCodec, [&](const TcpConnPtr &con, Slice msg) {
+            if (msg.size() == 0) {  //忽略空消息
                 return;
             }
             int cid = con->context<int>();
-            char* p = (char*)msg.data();
+            char *p = (char *) msg.data();
             intptr_t id = strtol(p, &p, 10);
-            p += *p == ' '; //忽略一个空格
-            string resp = util::format("%ld# %.*s", cid, msg.end()-p, p);
+            p += *p == ' ';  //忽略一个空格
+            string resp = util::format("%ld# %.*s", cid, msg.end() - p, p);
 
             int sended = 0;
-            if (id == 0) { //发给其他所有用户
-                for(auto& pc: users) {
+            if (id == 0) {  //发给其他所有用户
+                for (auto &pc : users) {
                     if (pc.first != cid) {
-                        sended ++;
+                        sended++;
                         pc.second->sendMsg(resp);
                     }
                 }
-            } else { //发给特定用户
+            } else {  //发给特定用户
                 auto p1 = users.find(id);
                 if (p1 != users.end()) {
-                    sended ++;
+                    sended++;
                     p1->second->sendMsg(resp);
                 }
             }
@@ -59,4 +59,3 @@ int main(int argc, const char* argv[]) {
     info("program exited");
     return 0;
 }
-

--- a/examples/codec-cli.cc
+++ b/examples/codec-cli.cc
@@ -3,16 +3,14 @@
 using namespace std;
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     setloglevel("TRACE");
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
     TcpConnPtr con = TcpConn::createConnection(&base, "127.0.0.1", 2099, 3000);
     con->setReconnectInterval(3000);
-    con->onMsg(new LengthCodec, [](const TcpConnPtr& con, Slice msg) {
-        info("recv msg: %.*s", (int)msg.size(), msg.data());
-    });
-    con->onState([=](const TcpConnPtr& con) {
+    con->onMsg(new LengthCodec, [](const TcpConnPtr &con, Slice msg) { info("recv msg: %.*s", (int) msg.size(), msg.data()); });
+    con->onState([=](const TcpConnPtr &con) {
         info("onState called state: %d", con->getState());
         if (con->getState() == TcpConn::Connected) {
             con->sendMsg("hello");

--- a/examples/codec-svr.cc
+++ b/examples/codec-svr.cc
@@ -3,18 +3,17 @@
 using namespace std;
 using namespace handy;
 
-
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     Logger::getLogger().setLogLevel(Logger::LTRACE);
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
 
     TcpServerPtr echo = TcpServer::startServer(&base, "", 2099);
     exitif(echo == NULL, "start tcp server failed");
-    echo->onConnCreate([]{
+    echo->onConnCreate([] {
         TcpConnPtr con(new TcpConn);
-        con->onMsg(new LengthCodec, [](const TcpConnPtr& con, Slice msg) {
-            info("recv msg: %.*s", (int)msg.size(), msg.data());
+        con->onMsg(new LengthCodec, [](const TcpConnPtr &con, Slice msg) {
+            info("recv msg: %.*s", (int) msg.size(), msg.data());
             con->sendMsg(msg);
         });
         return con;

--- a/examples/daemon.cc
+++ b/examples/daemon.cc
@@ -3,8 +3,7 @@
 using namespace std;
 using namespace handy;
 
-
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     if (argc != 2) {
         printf("usage: %s <start|stop|restart>\n", argv[0]);
         return 1;
@@ -19,22 +18,17 @@ int main(int argc, const char* argv[]) {
     string logfile = conf.get("", "logfile", program + ".log");
     string loglevel = conf.get("", "loglevel", "INFO");
     long rotateInterval = conf.getInteger("", "log_rotate_interval", 86400);
-    fprintf(stderr, "conf: file: %s level: %s interval: %ld\n",
-        logfile.c_str(), loglevel.c_str(), rotateInterval);
+    fprintf(stderr, "conf: file: %s level: %s interval: %ld\n", logfile.c_str(), loglevel.c_str(), rotateInterval);
     Logger::getLogger().setFileName(logfile.c_str());
     Logger::getLogger().setLogLevel(loglevel.c_str());
     Logger::getLogger().setRotateInterval(rotateInterval);
 
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
     TcpServerPtr echo = TcpServer::startServer(&base, "", 2099);
     exitif(echo == NULL, "start tcp server failed");
-    echo->onConnRead(
-        [](const TcpConnPtr& con) { 
-            con->send(con->getInput());
-        }
-    );
-    base.runAfter(1000, []{ info("log");}, 1000);
+    echo->onConnRead([](const TcpConnPtr &con) { con->send(con->getInput()); });
+    base.runAfter(1000, [] { info("log"); }, 1000);
     base.loop();
     info("program exited");
 }

--- a/examples/echo.cc
+++ b/examples/echo.cc
@@ -1,13 +1,11 @@
 #include <handy/handy.h>
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
     TcpServerPtr svr = TcpServer::startServer(&base, "", 2099);
     exitif(svr == NULL, "start tcp server failed");
-    svr->onConnRead([](const TcpConnPtr& con) {
-        con->send(con->getInput());
-    });
+    svr->onConnRead([](const TcpConnPtr &con) { con->send(con->getInput()); });
     base.loop();
 }

--- a/examples/hsha.cc
+++ b/examples/hsha.cc
@@ -3,32 +3,39 @@
 using namespace std;
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     setloglevel("TRACE");
     EventBase base;
     HSHAPtr hsha = HSHA::startServer(&base, "", 2099, 4);
     exitif(!hsha, "bind failed");
-    Signal::signal(SIGINT, [&, hsha]{ base.exit(); hsha->exit(); signal(SIGINT, SIG_DFL);});
+    Signal::signal(SIGINT, [&, hsha] {
+        base.exit();
+        hsha->exit();
+        signal(SIGINT, SIG_DFL);
+    });
 
-    hsha->onMsg(new LineCodec, [](const TcpConnPtr& con, const string& input){
+    hsha->onMsg(new LineCodec, [](const TcpConnPtr &con, const string &input) {
         int ms = rand() % 1000;
         info("processing a msg");
         usleep(ms * 1000);
         return util::format("%s used %d ms", input.c_str(), ms);
     });
-    for (int i = 0; i < 5; i ++) {
+    for (int i = 0; i < 5; i++) {
         TcpConnPtr con = TcpConn::createConnection(&base, "localhost", 2099);
-        con->onMsg(new LineCodec, [](const TcpConnPtr& con, Slice msg) {
-            info("%.*s recved", (int)msg.size(), msg.data());
+        con->onMsg(new LineCodec, [](const TcpConnPtr &con, Slice msg) {
+            info("%.*s recved", (int) msg.size(), msg.data());
             con->close();
         });
-        con->onState([](const TcpConnPtr& con) {
+        con->onState([](const TcpConnPtr &con) {
             if (con->getState() == TcpConn::Connected) {
                 con->sendMsg("hello");
             }
         });
     }
-    base.runAfter(1000, [&, hsha]{base.exit(); hsha->exit(); });
+    base.runAfter(1000, [&, hsha] {
+        base.exit();
+        hsha->exit();
+    });
     base.loop();
     info("program exited");
 }

--- a/examples/http-hello.cc
+++ b/examples/http-hello.cc
@@ -3,7 +3,7 @@
 using namespace std;
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     int threads = 1;
     if (argc > 1) {
         threads = atoi(argv[1]);
@@ -13,7 +13,7 @@ int main(int argc, const char* argv[]) {
     HttpServer sample(&base);
     int r = sample.bind("", 8081);
     exitif(r, "bind failed %d %s", errno, strerror(errno));
-    sample.onGet("/hello", [](const HttpConnPtr& con) {
+    sample.onGet("/hello", [](const HttpConnPtr &con) {
         string v = con.getRequest().version;
         HttpResponse resp;
         resp.body = Slice("hello world");
@@ -22,7 +22,7 @@ int main(int argc, const char* argv[]) {
             con->close();
         }
     });
-    Signal::signal(SIGINT, [&]{base.exit();});
+    Signal::signal(SIGINT, [&] { base.exit(); });
     base.loop();
     return 0;
 }

--- a/examples/idle-close.cc
+++ b/examples/idle-close.cc
@@ -1,21 +1,21 @@
 #include <handy/handy.h>
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     setloglevel("TRACE");
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
     TcpServerPtr svr = TcpServer::startServer(&base, "", 2099);
     exitif(svr == NULL, "start tcp server failed");
-    svr->onConnState([](const TcpConnPtr& con) {
+    svr->onConnState([](const TcpConnPtr &con) {
         if (con->getState() == TcpConn::Connected) {
-            con->addIdleCB(2, [](const TcpConnPtr& con){
+            con->addIdleCB(2, [](const TcpConnPtr &con) {
                 info("idle for 2 seconds, close connection");
                 con->close();
             });
         }
     });
     auto con = TcpConn::createConnection(&base, "localhost", 2099);
-    base.runAfter(3000, [&](){base.exit();});
+    base.runAfter(3000, [&]() { base.exit(); });
     base.loop();
 }

--- a/examples/reconnect.cc
+++ b/examples/reconnect.cc
@@ -1,20 +1,23 @@
 #include <handy/handy.h>
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     setloglevel("TRACE");
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
     TcpServerPtr svr = TcpServer::startServer(&base, "", 2099);
     exitif(svr == NULL, "start tcp server failed");
-    svr->onConnState([&](const TcpConnPtr& con) { //200ms后关闭连接
+    svr->onConnState([&](const TcpConnPtr &con) {  // 200ms后关闭连接
         if (con->getState() == TcpConn::Connected)
-            base.runAfter(200, [con](){ info("close con after 200ms"); con->close(); });
+            base.runAfter(200, [con]() {
+                info("close con after 200ms");
+                con->close();
+            });
     });
     TcpConnPtr con1 = TcpConn::createConnection(&base, "localhost", 2099);
     con1->setReconnectInterval(300);
-//    TcpConnPtr con2 = TcpConn::createConnection(&base, "localhost", 1, 100);
-//    con2->setReconnectInterval(200);
-    base.runAfter(600, [&](){base.exit();});
+    //    TcpConnPtr con2 = TcpConn::createConnection(&base, "localhost", 1, 100);
+    //    con2->setReconnectInterval(200);
+    base.runAfter(600, [&]() { base.exit(); });
     base.loop();
 }

--- a/examples/safe-close.cc
+++ b/examples/safe-close.cc
@@ -1,18 +1,18 @@
 #include <handy/handy.h>
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
     TcpServerPtr svr = TcpServer::startServer(&base, "", 2099);
     exitif(svr == NULL, "start tcp server failed");
     TcpConnPtr con = TcpConn::createConnection(&base, "localhost", 2099);
-    std::thread th([con,&base](){
+    std::thread th([con, &base]() {
         sleep(1);
         info("thread want to close an connection");
-        base.safeCall([con](){ con->close(); }); //其他线程需要操作连接，应当通过safeCall把操作交给io线程来做
+        base.safeCall([con]() { con->close(); });  //其他线程需要操作连接，应当通过safeCall把操作交给io线程来做
     });
-    base.runAfter(1500, [&base](){base.exit();});
+    base.runAfter(1500, [&base]() { base.exit(); });
     base.loop();
     th.join();
 }

--- a/examples/stat.cc
+++ b/examples/stat.cc
@@ -4,23 +4,35 @@
 using namespace std;
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     Logger::getLogger().setLogLevel("DEBUG");
     EventBase base;
     StatServer sample(&base);
     int r = sample.bind("", 80);
     exitif(r, "bind failed %d %s", errno, strerror(errno));
-    sample.onState("loglevel", "log level for server", []{return Logger::getLogger().getLogLevelStr(); });
+    sample.onState("loglevel", "log level for server", [] { return Logger::getLogger().getLogLevelStr(); });
     sample.onState("pid", "process id of server", [] { return util::format("%d", getpid()); });
-    sample.onCmd("lesslog", "set log to less detail", []{ Logger::getLogger().adjustLogLevel(-1); return "OK"; });
-    sample.onCmd("morelog", "set log to more detail", [] { Logger::getLogger().adjustLogLevel(1); return "OK"; });
-    sample.onCmd("restart", "restart program", [&] { 
-        base.safeCall([&]{ base.exit(); Daemon::changeTo(argv);}); 
-        return "restarting"; 
+    sample.onCmd("lesslog", "set log to less detail", [] {
+        Logger::getLogger().adjustLogLevel(-1);
+        return "OK";
     });
-    sample.onCmd("stop", "stop program", [&] { base.safeCall([&]{base.exit();}); return "stoping"; });
+    sample.onCmd("morelog", "set log to more detail", [] {
+        Logger::getLogger().adjustLogLevel(1);
+        return "OK";
+    });
+    sample.onCmd("restart", "restart program", [&] {
+        base.safeCall([&] {
+            base.exit();
+            Daemon::changeTo(argv);
+        });
+        return "restarting";
+    });
+    sample.onCmd("stop", "stop program", [&] {
+        base.safeCall([&] { base.exit(); });
+        return "stoping";
+    });
     sample.onPage("page", "show page content", [] { return "this is a page"; });
-    Signal::signal(SIGINT, [&]{base.exit();});
+    Signal::signal(SIGINT, [&] { base.exit(); });
     base.loop();
     return 0;
 }

--- a/examples/timer.cc
+++ b/examples/timer.cc
@@ -1,25 +1,17 @@
 #include <handy/handy.h>
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
     info("program begin");
-    base.runAfter(200, [](){
-        info("a task in runAfter 200ms");
-    });
-    base.runAfter(100, [](){
-        info("a task in runAfter 100ms interval 1000ms");
-    }, 1000);
-    TimerId id = base.runAt(time(NULL)*1000+300, [](){
-        info("a task in runAt now+300 interval 500ms");
-    }, 500);
-    base.runAfter(2000, [&](){
+    base.runAfter(200, []() { info("a task in runAfter 200ms"); });
+    base.runAfter(100, []() { info("a task in runAfter 100ms interval 1000ms"); }, 1000);
+    TimerId id = base.runAt(time(NULL) * 1000 + 300, []() { info("a task in runAt now+300 interval 500ms"); }, 500);
+    base.runAfter(2000, [&]() {
         info("cancel task of interval 500ms");
         base.cancel(id);
     });
-    base.runAfter(3000, [&](){
-        base.exit();
-    });
+    base.runAfter(3000, [&]() { base.exit(); });
     base.loop();
 }

--- a/examples/udp-cli.cc
+++ b/examples/udp-cli.cc
@@ -2,16 +2,13 @@
 #include <handy/handy.h>
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     setloglevel("TRACE");
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
     UdpConnPtr con = UdpConn::createConnection(&base, "127.0.0.1", 2099);
     exitif(!con, "start udp conn failed");
-    con->onMsg([](const UdpConnPtr& p, Buffer buf) {
-        info("udp recved %lu bytes", buf.size());
-    });
-    base.runAfter(0, [=](){con->send("hello");}, 1000);
+    con->onMsg([](const UdpConnPtr &p, Buffer buf) { info("udp recved %lu bytes", buf.size()); });
+    base.runAfter(0, [=]() { con->send("hello"); }, 1000);
     base.loop();
 }
-

--- a/examples/udp-hsha.cc
+++ b/examples/udp-hsha.cc
@@ -3,29 +3,37 @@
 using namespace std;
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     setloglevel("TRACE");
     EventBase base;
     HSHAUPtr hsha = HSHAU::startServer(&base, "", 2099, 1);
     exitif(!hsha, "bind failed");
-    Signal::signal(SIGINT, [&, hsha]{ base.exit(); hsha->exit(); signal(SIGINT, SIG_DFL);});
+    Signal::signal(SIGINT, [&, hsha] {
+        base.exit();
+        hsha->exit();
+        signal(SIGINT, SIG_DFL);
+    });
 
-    hsha->onMsg([](const UdpServerPtr& con, const string& input, Ip4Addr addr){
+    hsha->onMsg([](const UdpServerPtr &con, const string &input, Ip4Addr addr) {
         int ms = rand() % 1000 + 500;
-        info("processing a msg: %.*s will using %d ms", (int)input.length(), input.data(), ms);
+        info("processing a msg: %.*s will using %d ms", (int) input.length(), input.data(), ms);
         usleep(ms * 1000);
         info("msg processed");
         return util::format("%s used %d ms", input.c_str(), ms);
     });
-    for (int i = 0; i < 1; i ++) {
+    for (int i = 0; i < 1; i++) {
         UdpConnPtr con = UdpConn::createConnection(&base, "localhost", 2099);
-        con->onMsg([](const UdpConnPtr& con, Buffer buf) {
-            info("%.*s recved", (int)buf.size(), buf.data());
+        con->onMsg([](const UdpConnPtr &con, Buffer buf) {
+            info("%.*s recved", (int) buf.size(), buf.data());
             con->close();
         });
         con->send("hello");
     }
-    base.runAfter(500, [&,hsha]{info("exiting"); base.exit(); hsha->exit(); });
+    base.runAfter(500, [&, hsha] {
+        info("exiting");
+        base.exit();
+        hsha->exit();
+    });
     base.loop();
     info("program exited");
 }

--- a/examples/udp-svr.cc
+++ b/examples/udp-svr.cc
@@ -2,13 +2,13 @@
 #include <handy/handy.h>
 using namespace handy;
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     setloglevel("TRACE");
     EventBase base;
-    Signal::signal(SIGINT, [&]{ base.exit(); });
+    Signal::signal(SIGINT, [&] { base.exit(); });
     UdpServerPtr svr = UdpServer::startServer(&base, "", 2099);
     exitif(!svr, "start udp server failed");
-    svr->onMsg([](const UdpServerPtr& p, Buffer buf, Ip4Addr peer) {
+    svr->onMsg([](const UdpServerPtr &p, Buffer buf, Ip4Addr peer) {
         info("echo msg: %s to %s", buf.data(), peer.toString().c_str());
         p->sendTo(buf, peer);
     });

--- a/examples/write-on-empty.cc
+++ b/examples/write-on-empty.cc
@@ -3,19 +3,19 @@
 using namespace std;
 using namespace handy;
 
-char buf[20*1024*1024];
+char buf[20 * 1024 * 1024];
 
-int main(int argc, const char* argv[]) {
+int main(int argc, const char *argv[]) {
     setloglevel("TRACE");
-    int sended = 0, total=1054768*100;
+    int sended = 0, total = 1054768 * 100;
     memset(buf, 'a', sizeof buf);
     EventBase bases;
-    Signal::signal(SIGINT, [&]{ bases.exit(); });
+    Signal::signal(SIGINT, [&] { bases.exit(); });
     TcpServer echo(&bases);
     int r = echo.bind("", 2099);
     exitif(r, "bind failed %d %s", errno, strerror(errno));
-    auto sendcb = [&](const TcpConnPtr& con) {
-        while(con->getOutput().size() == 0 && sended < total) {
+    auto sendcb = [&](const TcpConnPtr &con) {
+        while (con->getOutput().size() == 0 && sended < total) {
             con->send(buf, sizeof buf);
             sended += sizeof buf;
             info("%d bytes sended output size: %lu", sended, con->getOutput().size());
@@ -27,7 +27,7 @@ int main(int argc, const char* argv[]) {
     };
     echo.onConnCreate([sendcb]() {
         TcpConnPtr con(new TcpConn);
-        con->onState([sendcb](const TcpConnPtr& con) {
+        con->onState([sendcb](const TcpConnPtr &con) {
             if (con->getState() == TcpConn::Connected) {
                 con->onWritable(sendcb);
             }
@@ -35,15 +35,15 @@ int main(int argc, const char* argv[]) {
         });
         return con;
     });
-    thread th([]{ //模拟了一个客户端，连接服务器后，接收服务器发送过来的数据
+    thread th([] {  //模拟了一个客户端，连接服务器后，接收服务器发送过来的数据
         EventBase base2;
         TcpConnPtr con = TcpConn::createConnection(&base2, "127.0.0.1", 2099);
-        con->onRead([](const TcpConnPtr& con){
+        con->onRead([](const TcpConnPtr &con) {
             info("recv %lu bytes", con->getInput().size());
             con->getInput().clear();
             sleep(1);
         });
-        con->onState([&](const TcpConnPtr& con){
+        con->onState([&](const TcpConnPtr &con) {
             if (con->getState() == TcpConn::Closed || con->getState() == TcpConn::Failed) {
                 base2.exit();
             }

--- a/handy/codec.cc
+++ b/handy/codec.cc
@@ -4,45 +4,44 @@ using namespace std;
 
 namespace handy {
 
-int LineCodec::tryDecode(Slice data, Slice& msg) {
+int LineCodec::tryDecode(Slice data, Slice &msg) {
     if (data.size() == 1 && data[0] == 0x04) {
         msg = data;
         return 1;
     }
-    for (size_t i = 0; i < data.size(); i ++) {
+    for (size_t i = 0; i < data.size(); i++) {
         if (data[i] == '\n') {
-            if (i > 0 && data[i-1] == '\r') {
-                msg = Slice(data.data(), i-1);
-                return i+1;
+            if (i > 0 && data[i - 1] == '\r') {
+                msg = Slice(data.data(), i - 1);
+                return i + 1;
             } else {
                 msg = Slice(data.data(), i);
-                return i+1;
+                return i + 1;
             }
         }
     }
     return 0;
 }
-void LineCodec::encode(Slice msg, Buffer& buf) {
+void LineCodec::encode(Slice msg, Buffer &buf) {
     buf.append(msg).append("\r\n");
 }
 
-int LengthCodec::tryDecode(Slice data, Slice& msg) {
+int LengthCodec::tryDecode(Slice data, Slice &msg) {
     if (data.size() < 8) {
         return 0;
     }
-    int len = net::ntoh(*(int32_t*)(data.data()+4));
-    if (len > 1024*1024 || memcmp(data.data(), "mBdT", 4) != 0) {
+    int len = net::ntoh(*(int32_t *) (data.data() + 4));
+    if (len > 1024 * 1024 || memcmp(data.data(), "mBdT", 4) != 0) {
         return -1;
     }
-    if ((int)data.size() >= len+8) {
-        msg = Slice(data.data()+8, len);
-        return len+8;
+    if ((int) data.size() >= len + 8) {
+        msg = Slice(data.data() + 8, len);
+        return len + 8;
     }
     return 0;
 }
-void LengthCodec::encode(Slice msg, Buffer& buf) {
-    buf.append("mBdT").appendValue(net::hton((int32_t)msg.size())).append(msg);
+void LengthCodec::encode(Slice msg, Buffer &buf) {
+    buf.append("mBdT").appendValue(net::hton((int32_t) msg.size())).append(msg);
 }
 
-
-}
+}  // namespace handy

--- a/handy/codec.h
+++ b/handy/codec.h
@@ -1,29 +1,29 @@
 #pragma once
-#include "slice.h"
 #include "net.h"
+#include "slice.h"
 namespace handy {
 
 struct CodecBase {
     // > 0 解析出完整消息，消息放在msg中，返回已扫描的字节数
     // == 0 解析部分消息
     // < 0 解析错误
-    virtual int tryDecode(Slice data, Slice& msg) = 0;
-    virtual void encode(Slice msg, Buffer& buf) = 0;
-    virtual CodecBase* clone() = 0;
+    virtual int tryDecode(Slice data, Slice &msg) = 0;
+    virtual void encode(Slice msg, Buffer &buf) = 0;
+    virtual CodecBase *clone() = 0;
 };
 
 //以\r\n结尾的消息
-struct LineCodec: public CodecBase{
-    int tryDecode(Slice data, Slice& msg) override;
-    void encode(Slice msg, Buffer& buf) override;
-    CodecBase* clone() override { return new LineCodec(); }
+struct LineCodec : public CodecBase {
+    int tryDecode(Slice data, Slice &msg) override;
+    void encode(Slice msg, Buffer &buf) override;
+    CodecBase *clone() override { return new LineCodec(); }
 };
 
 //给出长度的消息
-struct LengthCodec:public CodecBase {
-    int tryDecode(Slice data, Slice& msg) override;
-    void encode(Slice msg, Buffer& buf) override;
-    CodecBase* clone() override { return new LengthCodec(); }
+struct LengthCodec : public CodecBase {
+    int tryDecode(Slice data, Slice &msg) override;
+    void encode(Slice msg, Buffer &buf) override;
+    CodecBase *clone() override { return new LengthCodec(); }
 };
 
-};
+};  // namespace handy

--- a/handy/conf.cc
+++ b/handy/conf.cc
@@ -1,7 +1,7 @@
 #include "conf.h"
+#include <stdlib.h>
 #include <algorithm>
 #include <memory>
-#include <stdlib.h>
 
 using namespace std;
 
@@ -28,8 +28,8 @@ list<string> Conf::getStrings(string section, string name) {
 
 long Conf::getInteger(string section, string name, long default_value) {
     string valstr = get(section, name, "");
-    const char* value = valstr.c_str();
-    char* end;
+    const char *value = valstr.c_str();
+    char *end;
     // This parses "1234" (decimal) and also "0x4D2" (hex)
     long n = strtol(value, &end, 0);
     return end > value ? n : default_value;
@@ -37,8 +37,8 @@ long Conf::getInteger(string section, string name, long default_value) {
 
 double Conf::getReal(string section, string name, double default_value) {
     string valstr = get(section, name, "");
-    const char* value = valstr.c_str();
-    char* end;
+    const char *value = valstr.c_str();
+    char *end;
     double n = strtod(value, &end);
     return end > value ? n : default_value;
 }
@@ -56,66 +56,75 @@ bool Conf::getBoolean(string section, string name, bool default_value) {
 }
 
 namespace {
-    struct LineScanner {
-        char* p;
-        int err;
-        LineScanner(char* ln): p(ln), err(0) {}
-        LineScanner& skipSpaces() {
-            while(!err && *p && isspace(*p)) {
-                p++;
-            }
-            return *this;
+struct LineScanner {
+    char *p;
+    int err;
+    LineScanner(char *ln) : p(ln), err(0) {}
+    LineScanner &skipSpaces() {
+        while (!err && *p && isspace(*p)) {
+            p++;
         }
-        string rstrip(char* s, char* e) {
-            while (e > s && isspace(e[-1])) {
-                e --;
-            }
-            return string(s, e);
+        return *this;
+    }
+    string rstrip(char *s, char *e) {
+        while (e > s && isspace(e[-1])) {
+            e--;
         }
-        int peekChar() { skipSpaces(); return *p; }
-        LineScanner& skip(int i) { p += i; return *this; }
-        LineScanner& match(char c) { skipSpaces(); err = *p++ != c; return *this; }
-        string consumeTill(char c) {
-            skipSpaces();
-            char* e = p;
-            while (!err && *e && *e != c) {
-                e ++;
-            }
-            if (*e != c) {
-                err = 1;
-                return "";
-            }
-            char* s = p;
-            p = e;
-            return rstrip(s, e);
+        return string(s, e);
+    }
+    int peekChar() {
+        skipSpaces();
+        return *p;
+    }
+    LineScanner &skip(int i) {
+        p += i;
+        return *this;
+    }
+    LineScanner &match(char c) {
+        skipSpaces();
+        err = *p++ != c;
+        return *this;
+    }
+    string consumeTill(char c) {
+        skipSpaces();
+        char *e = p;
+        while (!err && *e && *e != c) {
+            e++;
         }
-        string consumeTillEnd() {
-            skipSpaces();
-            char* e = p;
-            int wasspace = 0;
-            while (!err && *e && *e != ';' && *e != '#') {
-                if (wasspace) {
-                    break;
-                }
-                wasspace = isspace(*e);
-                e ++;
-            }
-            char* s = p;
-            p = e;
-            return rstrip(s, e);
+        if (*e != c) {
+            err = 1;
+            return "";
         }
+        char *s = p;
+        p = e;
+        return rstrip(s, e);
+    }
+    string consumeTillEnd() {
+        skipSpaces();
+        char *e = p;
+        int wasspace = 0;
+        while (!err && *e && *e != ';' && *e != '#') {
+            if (wasspace) {
+                break;
+            }
+            wasspace = isspace(*e);
+            e++;
+        }
+        char *s = p;
+        p = e;
+        return rstrip(s, e);
+    }
+};
+}  // namespace
 
-    };
-}
-
-int Conf::parse(const string& filename) {
+int Conf::parse(const string &filename) {
     this->filename = filename;
-    FILE* file = fopen(this->filename.c_str(), "r");
+    FILE *file = fopen(this->filename.c_str(), "r");
     if (!file)
         return -1;
-    unique_ptr<FILE, decltype(fclose)*> release2(file, fclose);
+    unique_ptr<FILE, decltype(fclose) *> release2(file, fclose);
     static const int MAX_LINE = 16 * 1024;
-    char* ln = new char[MAX_LINE];
+    char *ln = new char[MAX_LINE];
     unique_ptr<char[]> release1(ln);
     int lineno = 0;
     string section, key;
@@ -153,8 +162,6 @@ int Conf::parse(const string& filename) {
         }
     }
     return err ? lineno : 0;
-
 }
 
-
-}
+}  // namespace handy

--- a/handy/conf.h
+++ b/handy/conf.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <map>
 #include <list>
+#include <map>
 #include <string>
 
 namespace handy {
@@ -10,7 +10,7 @@ struct Conf {
     // 0 success
     // -1 IOERROR
     // >0 line no of error
-    int parse(const std::string& filename);
+    int parse(const std::string &filename);
 
     // Get a string value from INI file, returning default_value if not found.
     std::string get(std::string section, std::string name, std::string default_value);
@@ -36,4 +36,4 @@ struct Conf {
     std::string filename;
 };
 
-}
+}  // namespace handy

--- a/handy/conn.h
+++ b/handy/conn.h
@@ -3,132 +3,162 @@
 
 namespace handy {
 
-//Tcp连接，使用引用计数
-    struct TcpConn: public std::enable_shared_from_this<TcpConn>, private noncopyable {
-        //Tcp连接的个状态
-        enum State { Invalid=1, Handshaking, Connected, Closed, Failed, };
-        //Tcp构造函数，实际可用的连接应当通过createConnection创建
-        TcpConn();
-        virtual ~TcpConn();
-        //可传入连接类型，返回智能指针
-        template<class C=TcpConn> static TcpConnPtr createConnection(EventBase* base, const std::string& host, short port,
-                                   int timeout=0, const std::string& localip="") {
-            TcpConnPtr con(new C); con->connect(base, host, port, timeout, localip); return con;
-        }
-        template<class C=TcpConn> static TcpConnPtr createConnection(EventBase* base, int fd, Ip4Addr local, Ip4Addr peer) {
-            TcpConnPtr con(new C); con->attach(base, fd, local, peer); return con;
-        }
-
-        bool isClient() { return destPort_ > 0; }
-        //automatically managed context. allocated when first used, deleted when destruct
-        template<class T> T& context() { return ctx_.context<T>(); }
-
-        EventBase* getBase() { return base_; }
-        State getState() { return state_; }
-        //TcpConn的输入输出缓冲区
-        Buffer& getInput() { return input_; }
-        Buffer& getOutput() { return output_; }
-
-        Channel* getChannel() { return channel_; }
-        bool writable() { return channel_ ? channel_->writeEnabled(): false; }
-
-        //发送数据
-        void sendOutput() { send(output_); }
-        void send(Buffer& msg);
-        void send(const char* buf, size_t len);
-        void send(const std::string& s) { send(s.data(), s.size()); }
-        void send(const char* s) { send(s, strlen(s)); }
-
-        //数据到达时回调
-        void onRead(const TcpCallBack& cb) { assert(!readcb_); readcb_ = cb; };
-        //当tcp缓冲区可写时回调
-        void onWritable(const TcpCallBack& cb) { writablecb_ = cb;}
-        //tcp状态改变时回调
-        void onState(const TcpCallBack& cb) { statecb_ = cb; }
-        //tcp空闲回调
-        void addIdleCB(int idle, const TcpCallBack& cb);
-
-        //消息回调，此回调与onRead回调冲突，只能够调用一个
-        //codec所有权交给onMsg
-        void onMsg(CodecBase* codec, const MsgCallBack& cb);
-        //发送消息
-        void sendMsg(Slice msg);
-
-        //conn会在下个事件周期进行处理
-        void close();
-        //设置重连时间间隔，-1: 不重连，0:立即重连，其它：等待毫秒数，未设置不重连
-        void setReconnectInterval(int milli) { reconnectInterval_ = milli; }
-
-        //!慎用。立即关闭连接，清理相关资源，可能导致该连接的引用计数变为0，从而使当前调用者引用的连接被析构
-        void closeNow() { if (channel_) channel_->close(); }
-
-        //远程地址的字符串
-        std::string str() { return peer_.toString(); }
-
-    public:
-        EventBase* base_;
-        Channel* channel_;
-        Buffer input_, output_;
-        Ip4Addr local_, peer_;
-        State state_;
-        TcpCallBack readcb_, writablecb_, statecb_;
-        std::list<IdleId> idleIds_;
-        TimerId timeoutId_;
-        AutoContext ctx_, internalCtx_;
-        std::string destHost_, localIp_;
-        int destPort_, connectTimeout_, reconnectInterval_;
-        int64_t connectedTime_;
-        std::unique_ptr<CodecBase> codec_;
-        void handleRead(const TcpConnPtr& con);
-        void handleWrite(const TcpConnPtr& con);
-        ssize_t isend(const char* buf, size_t len);
-        void cleanup(const TcpConnPtr& con);
-        void connect(EventBase* base, const std::string& host, short port, int timeout, const std::string& localip);
-        void reconnect();
-        void attach(EventBase* base, int fd, Ip4Addr local, Ip4Addr peer);
-        virtual int readImp(int fd, void* buf, size_t bytes) { return ::read(fd, buf, bytes); }
-        virtual int writeImp(int fd, const void* buf, size_t bytes) { return ::write(fd, buf, bytes); }
-        virtual int handleHandshake(const TcpConnPtr& con);
+// Tcp连接，使用引用计数
+struct TcpConn : public std::enable_shared_from_this<TcpConn>, private noncopyable {
+    // Tcp连接的个状态
+    enum State {
+        Invalid = 1,
+        Handshaking,
+        Connected,
+        Closed,
+        Failed,
     };
+    // Tcp构造函数，实际可用的连接应当通过createConnection创建
+    TcpConn();
+    virtual ~TcpConn();
+    //可传入连接类型，返回智能指针
+    template <class C = TcpConn>
+    static TcpConnPtr createConnection(EventBase *base, const std::string &host, short port, int timeout = 0, const std::string &localip = "") {
+        TcpConnPtr con(new C);
+        con->connect(base, host, port, timeout, localip);
+        return con;
+    }
+    template <class C = TcpConn>
+    static TcpConnPtr createConnection(EventBase *base, int fd, Ip4Addr local, Ip4Addr peer) {
+        TcpConnPtr con(new C);
+        con->attach(base, fd, local, peer);
+        return con;
+    }
 
-//Tcp服务器
-    struct TcpServer: private noncopyable {
-        TcpServer(EventBases* bases);
-        //return 0 on sucess, errno on error
-        int bind(const std::string& host, short port, bool reusePort=false);
-        static TcpServerPtr startServer(EventBases* bases, const std::string& host, short port, bool reusePort=false);
-        ~TcpServer() { delete listen_channel_; }
-        Ip4Addr getAddr() { return addr_; }
-        EventBase* getBase() { return base_; }
-        void onConnCreate(const std::function<TcpConnPtr()>& cb) { createcb_ = cb; }
-        void onConnState(const TcpCallBack& cb) { statecb_ = cb; }
-        void onConnRead(const TcpCallBack& cb) { readcb_ = cb; assert(!msgcb_); }
-        // 消息处理与Read回调冲突，只能调用一个
-        void onConnMsg(CodecBase* codec, const MsgCallBack& cb) { codec_.reset(codec); msgcb_ = cb; assert(!readcb_); }
-    private:
-        EventBase* base_;
-        EventBases* bases_;
-        Ip4Addr addr_;
-        Channel* listen_channel_;
-        TcpCallBack statecb_, readcb_;
-        MsgCallBack msgcb_;
-        std::function<TcpConnPtr()> createcb_;
-        std::unique_ptr<CodecBase> codec_;
-        void handleAccept();
+    bool isClient() { return destPort_ > 0; }
+    // automatically managed context. allocated when first used, deleted when destruct
+    template <class T>
+    T &context() {
+        return ctx_.context<T>();
+    }
+
+    EventBase *getBase() { return base_; }
+    State getState() { return state_; }
+    // TcpConn的输入输出缓冲区
+    Buffer &getInput() { return input_; }
+    Buffer &getOutput() { return output_; }
+
+    Channel *getChannel() { return channel_; }
+    bool writable() { return channel_ ? channel_->writeEnabled() : false; }
+
+    //发送数据
+    void sendOutput() { send(output_); }
+    void send(Buffer &msg);
+    void send(const char *buf, size_t len);
+    void send(const std::string &s) { send(s.data(), s.size()); }
+    void send(const char *s) { send(s, strlen(s)); }
+
+    //数据到达时回调
+    void onRead(const TcpCallBack &cb) {
+        assert(!readcb_);
+        readcb_ = cb;
     };
+    //当tcp缓冲区可写时回调
+    void onWritable(const TcpCallBack &cb) { writablecb_ = cb; }
+    // tcp状态改变时回调
+    void onState(const TcpCallBack &cb) { statecb_ = cb; }
+    // tcp空闲回调
+    void addIdleCB(int idle, const TcpCallBack &cb);
 
-    typedef std::function<std::string (const TcpConnPtr&, const std::string& msg)> RetMsgCallBack;
-    //半同步半异步服务器
-    struct HSHA;
-    typedef std::shared_ptr<HSHA> HSHAPtr;
-    struct HSHA {
-        static HSHAPtr startServer(EventBase* base, const std::string& host, short port, int threads);
-        HSHA(int threads): threadPool_(threads) {}
-        void exit() {threadPool_.exit(); threadPool_.join(); }
-        void onMsg(CodecBase* codec, const RetMsgCallBack& cb);
-        TcpServerPtr server_;
-        ThreadPool threadPool_;
-    };
+    //消息回调，此回调与onRead回调冲突，只能够调用一个
+    // codec所有权交给onMsg
+    void onMsg(CodecBase *codec, const MsgCallBack &cb);
+    //发送消息
+    void sendMsg(Slice msg);
 
+    // conn会在下个事件周期进行处理
+    void close();
+    //设置重连时间间隔，-1: 不重连，0:立即重连，其它：等待毫秒数，未设置不重连
+    void setReconnectInterval(int milli) { reconnectInterval_ = milli; }
 
-}
+    //!慎用。立即关闭连接，清理相关资源，可能导致该连接的引用计数变为0，从而使当前调用者引用的连接被析构
+    void closeNow() {
+        if (channel_)
+            channel_->close();
+    }
+
+    //远程地址的字符串
+    std::string str() { return peer_.toString(); }
+
+   public:
+    EventBase *base_;
+    Channel *channel_;
+    Buffer input_, output_;
+    Ip4Addr local_, peer_;
+    State state_;
+    TcpCallBack readcb_, writablecb_, statecb_;
+    std::list<IdleId> idleIds_;
+    TimerId timeoutId_;
+    AutoContext ctx_, internalCtx_;
+    std::string destHost_, localIp_;
+    int destPort_, connectTimeout_, reconnectInterval_;
+    int64_t connectedTime_;
+    std::unique_ptr<CodecBase> codec_;
+    void handleRead(const TcpConnPtr &con);
+    void handleWrite(const TcpConnPtr &con);
+    ssize_t isend(const char *buf, size_t len);
+    void cleanup(const TcpConnPtr &con);
+    void connect(EventBase *base, const std::string &host, short port, int timeout, const std::string &localip);
+    void reconnect();
+    void attach(EventBase *base, int fd, Ip4Addr local, Ip4Addr peer);
+    virtual int readImp(int fd, void *buf, size_t bytes) { return ::read(fd, buf, bytes); }
+    virtual int writeImp(int fd, const void *buf, size_t bytes) { return ::write(fd, buf, bytes); }
+    virtual int handleHandshake(const TcpConnPtr &con);
+};
+
+// Tcp服务器
+struct TcpServer : private noncopyable {
+    TcpServer(EventBases *bases);
+    // return 0 on sucess, errno on error
+    int bind(const std::string &host, short port, bool reusePort = false);
+    static TcpServerPtr startServer(EventBases *bases, const std::string &host, short port, bool reusePort = false);
+    ~TcpServer() { delete listen_channel_; }
+    Ip4Addr getAddr() { return addr_; }
+    EventBase *getBase() { return base_; }
+    void onConnCreate(const std::function<TcpConnPtr()> &cb) { createcb_ = cb; }
+    void onConnState(const TcpCallBack &cb) { statecb_ = cb; }
+    void onConnRead(const TcpCallBack &cb) {
+        readcb_ = cb;
+        assert(!msgcb_);
+    }
+    // 消息处理与Read回调冲突，只能调用一个
+    void onConnMsg(CodecBase *codec, const MsgCallBack &cb) {
+        codec_.reset(codec);
+        msgcb_ = cb;
+        assert(!readcb_);
+    }
+
+   private:
+    EventBase *base_;
+    EventBases *bases_;
+    Ip4Addr addr_;
+    Channel *listen_channel_;
+    TcpCallBack statecb_, readcb_;
+    MsgCallBack msgcb_;
+    std::function<TcpConnPtr()> createcb_;
+    std::unique_ptr<CodecBase> codec_;
+    void handleAccept();
+};
+
+typedef std::function<std::string(const TcpConnPtr &, const std::string &msg)> RetMsgCallBack;
+//半同步半异步服务器
+struct HSHA;
+typedef std::shared_ptr<HSHA> HSHAPtr;
+struct HSHA {
+    static HSHAPtr startServer(EventBase *base, const std::string &host, short port, int threads);
+    HSHA(int threads) : threadPool_(threads) {}
+    void exit() {
+        threadPool_.exit();
+        threadPool_.join();
+    }
+    void onMsg(CodecBase *codec, const RetMsgCallBack &cb);
+    TcpServerPtr server_;
+    ThreadPool threadPool_;
+};
+
+}  // namespace handy

--- a/handy/daemon.cc
+++ b/handy/daemon.cc
@@ -1,19 +1,19 @@
 #include "daemon.h"
-#include <functional>
-#include <utility>
 #include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <signal.h>
 #include <string.h>
-#include <time.h>
 #include <strings.h>
-#include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
+#include <sys/types.h>
+#include <time.h>
 #include <unistd.h>
+#include <functional>
 #include <map>
 #include <string>
+#include <utility>
 
 using namespace std;
 
@@ -23,17 +23,17 @@ namespace {
 
 struct ExitCaller {
     ~ExitCaller() { functor_(); }
-    ExitCaller(std::function<void()>&& functor): functor_(std::move(functor)) {}
-private:
+    ExitCaller(std::function<void()> &&functor) : functor_(std::move(functor)) {}
+
+   private:
     std::function<void()> functor_;
 };
 
-}
+}  // namespace
 
-static int writePidFile(const char *pidfile)
-{
+static int writePidFile(const char *pidfile) {
     char str[32];
-    int lfp = open(pidfile, O_WRONLY|O_CREAT|O_TRUNC, 0600);
+    int lfp = open(pidfile, O_WRONLY | O_CREAT | O_TRUNC, 0600);
     if (lfp < 0 || lockf(lfp, F_TLOCK, 0) < 0) {
         fprintf(stderr, "Can't write Pid File: %s", pidfile);
         return -1;
@@ -42,15 +42,14 @@ static int writePidFile(const char *pidfile)
     sprintf(str, "%d\n", getpid());
     ssize_t len = strlen(str);
     ssize_t ret = write(lfp, str, len);
-    if (ret != len ) {
+    if (ret != len) {
         fprintf(stderr, "Can't Write Pid File: %s", pidfile);
         return -1;
     }
     return 0;
 }
 
-int Daemon::getPidFromFile(const char *pidfile)
-{
+int Daemon::getPidFromFile(const char *pidfile) {
     char buffer[64], *p;
     int lfp = open(pidfile, O_RDONLY, 0);
     if (lfp < 0) {
@@ -68,8 +67,7 @@ int Daemon::getPidFromFile(const char *pidfile)
     return atoi(buffer);
 }
 
-
-int Daemon::daemonStart(const char* pidfile) {
+int Daemon::daemonStart(const char *pidfile) {
     int pid = getPidFromFile(pidfile);
     if (pid > 0) {
         if (kill(pid, 0) == 0 || errno == EPERM) {
@@ -88,29 +86,27 @@ int Daemon::daemonStart(const char* pidfile) {
         return -1;
     }
     if (pid > 0) {
-        exit(0); // parent exit
+        exit(0);  // parent exit
     }
     setsid();
     int r = writePidFile(pidfile);
     if (r != 0) {
         return r;
     }
-    int fd =open("/dev/null", 0);
+    int fd = open("/dev/null", 0);
     if (fd >= 0) {
         close(0);
         dup2(fd, 0);
         dup2(fd, 1);
         close(fd);
         string pfile = pidfile;
-        static ExitCaller del([=] {
-            unlink(pfile.c_str());
-        });
+        static ExitCaller del([=] { unlink(pfile.c_str()); });
         return 0;
     }
     return -1;
 }
 
-int Daemon::daemonStop(const char* pidfile) {
+int Daemon::daemonStop(const char *pidfile) {
     int pid = getPidFromFile(pidfile);
     if (pid <= 0) {
         fprintf(stderr, "%s not exists or not valid\n", pidfile);
@@ -122,7 +118,7 @@ int Daemon::daemonStop(const char* pidfile) {
         return r;
     }
     for (int i = 0; i < 300; i++) {
-        usleep(10*1000);
+        usleep(10 * 1000);
         r = kill(pid, SIGQUIT);
         if (r != 0) {
             fprintf(stderr, "program %d exited\n", pid);
@@ -134,7 +130,7 @@ int Daemon::daemonStop(const char* pidfile) {
     return -1;
 }
 
-int Daemon::daemonRestart(const char* pidfile) {
+int Daemon::daemonRestart(const char *pidfile) {
     int pid = getPidFromFile(pidfile);
     if (pid > 0) {
         if (kill(pid, 0) == 0) {
@@ -152,59 +148,59 @@ int Daemon::daemonRestart(const char* pidfile) {
     return daemonStart(pidfile);
 }
 
-void Daemon::daemonProcess(const char* cmd, const char* pidfile) {
+void Daemon::daemonProcess(const char *cmd, const char *pidfile) {
     int r = 0;
-    if (cmd == NULL || strcmp(cmd, "start")==0) {
+    if (cmd == NULL || strcmp(cmd, "start") == 0) {
         r = daemonStart(pidfile);
-    } else if (strcmp(cmd, "stop")==0) {
+    } else if (strcmp(cmd, "stop") == 0) {
         r = daemonStop(pidfile);
         if (r == 0) {
             exit(0);
         }
-    } else if (strcmp(cmd, "restart")==0) {
+    } else if (strcmp(cmd, "restart") == 0) {
         r = daemonRestart(pidfile);
     } else {
         fprintf(stderr, "ERROR: bad daemon command. exit\n");
         r = -1;
     }
     if (r) {
-        //exit on error
+        // exit on error
         exit(1);
     }
 }
 
-void Daemon::changeTo(const char* argv[]) {
+void Daemon::changeTo(const char *argv[]) {
     int pid = getpid();
     int r = fork();
     if (r < 0) {
         fprintf(stderr, "fork error %d %s", errno, strerror(errno));
-    } else if (r > 0) { //parent;
+    } else if (r > 0) {  // parent;
         return;
-    } else { //child
-        //wait parent to exit
-        while(kill(pid, 0) == 0) {
-            usleep(10*1000);
+    } else {  // child
+        // wait parent to exit
+        while (kill(pid, 0) == 0) {
+            usleep(10 * 1000);
         }
         if (errno != ESRCH) {
-            const char* msg = "kill error\n";
+            const char *msg = "kill error\n";
             ssize_t w1 = write(2, msg, strlen(msg));
-            (void)w1;
+            (void) w1;
             _exit(1);
         }
-        execvp(argv[0], (char* const*)argv);
+        execvp(argv[0], (char *const *) argv);
     }
 }
 
 namespace {
-    map<int, function<void()>> handlers;
-    void signal_handler(int sig) {
-        handlers[sig]();
-    }
+map<int, function<void()>> handlers;
+void signal_handler(int sig) {
+    handlers[sig]();
 }
+}  // namespace
 
-void Signal::signal(int sig, const function<void()>& handler) {
+void Signal::signal(int sig, const function<void()> &handler) {
     handlers[sig] = handler;
     ::signal(sig, signal_handler);
 }
 
-}
+}  // namespace handy

--- a/handy/daemon.h
+++ b/handy/daemon.h
@@ -1,27 +1,27 @@
 #pragma once
-#include <functional>
 #include <signal.h>
+#include <functional>
 namespace handy {
 
 struct Daemon {
-    //exit in parent
-    static int daemonStart(const char* pidfile);
-    //exit in parent
-    static int daemonRestart(const char* pidfile);
-    static int daemonStop(const char* pidfile);
-    static int getPidFromFile(const char* pidfile);
+    // exit in parent
+    static int daemonStart(const char *pidfile);
+    // exit in parent
+    static int daemonRestart(const char *pidfile);
+    static int daemonStop(const char *pidfile);
+    static int getPidFromFile(const char *pidfile);
 
     // cmd: start stop restart
     // exit(1) when error
     // exit(0) when start or restart in parent
     // return when start or restart in child
-    static void daemonProcess(const char* cmd, const char* pidfile);
-    //fork; wait for parent to exit; exec argv
-    //you may use it to implement restart in program
-    static void changeTo(const char* argv[]);
+    static void daemonProcess(const char *cmd, const char *pidfile);
+    // fork; wait for parent to exit; exec argv
+    // you may use it to implement restart in program
+    static void changeTo(const char *argv[]);
 };
 
 struct Signal {
-    static void signal(int sig, const std::function<void()>& handler);
+    static void signal(int sig, const std::function<void()> &handler);
 };
-}
+}  // namespace handy

--- a/handy/event_base.h
+++ b/handy/event_base.h
@@ -6,65 +6,74 @@ namespace handy {
 
 typedef std::shared_ptr<TcpConn> TcpConnPtr;
 typedef std::shared_ptr<TcpServer> TcpServerPtr;
-typedef std::function<void(const TcpConnPtr&)> TcpCallBack;
-typedef std::function<void(const TcpConnPtr&, Slice msg)> MsgCallBack;
+typedef std::function<void(const TcpConnPtr &)> TcpCallBack;
+typedef std::function<void(const TcpConnPtr &, Slice msg)> MsgCallBack;
 
-struct EventBases: private noncopyable {
-    virtual EventBase* allocBase() = 0;
+struct EventBases : private noncopyable {
+    virtual EventBase *allocBase() = 0;
 };
 
 //事件派发器，可管理定时器，连接，超时连接
-struct EventBase: public EventBases {
-    //taskCapacity指定任务队列的大小，0无限制
-    EventBase(int taskCapacity=0);
+struct EventBase : public EventBases {
+    // taskCapacity指定任务队列的大小，0无限制
+    EventBase(int taskCapacity = 0);
     ~EventBase();
     //处理已到期的事件,waitMs表示若无当前需要处理的任务，需要等待的时间
     void loop_once(int waitMs);
     //进入事件处理循环
-    void loop() ;
+    void loop();
     //取消定时任务，若timer已经过期，则忽略
     bool cancel(TimerId timerid);
     //添加定时任务，interval=0表示一次性任务，否则为重复任务，时间为毫秒
-    TimerId runAt(int64_t milli, const Task& task, int64_t interval=0) { return runAt(milli, Task(task), interval); }
-    TimerId runAt(int64_t milli, Task&& task, int64_t interval=0);
-    TimerId runAfter(int64_t milli, const Task& task, int64_t interval=0) { return runAt(util::timeMilli()+milli, Task(task), interval); }
-    TimerId runAfter(int64_t milli, Task&& task, int64_t interval=0) { return runAt(util::timeMilli()+milli, std::move(task), interval);}
+    TimerId runAt(int64_t milli, const Task &task, int64_t interval = 0) { return runAt(milli, Task(task), interval); }
+    TimerId runAt(int64_t milli, Task &&task, int64_t interval = 0);
+    TimerId runAfter(int64_t milli, const Task &task, int64_t interval = 0) { return runAt(util::timeMilli() + milli, Task(task), interval); }
+    TimerId runAfter(int64_t milli, Task &&task, int64_t interval = 0) { return runAt(util::timeMilli() + milli, std::move(task), interval); }
 
     //下列函数为线程安全的
 
     //退出事件循环
-    EventBase& exit();
+    EventBase &exit();
     //是否已退出
     bool exited();
     //唤醒事件处理
     void wakeup();
     //添加任务
-    void safeCall(Task&& task);
-    void safeCall(const Task& task) { safeCall(Task(task)); }
+    void safeCall(Task &&task);
+    void safeCall(const Task &task) { safeCall(Task(task)); }
     //分配一个事件派发器
-    virtual EventBase* allocBase() { return this; }
+    virtual EventBase *allocBase() { return this; }
 
-public:
+   public:
     std::unique_ptr<EventsImp> imp_;
 };
 
 //多线程的事件派发器
-struct MultiBase: public EventBases{
-    MultiBase(int sz): id_(0), bases_(sz) {}
-    virtual EventBase* allocBase() { int c = id_++; return &bases_[c%bases_.size()]; }
+struct MultiBase : public EventBases {
+    MultiBase(int sz) : id_(0), bases_(sz) {}
+    virtual EventBase *allocBase() {
+        int c = id_++;
+        return &bases_[c % bases_.size()];
+    }
     void loop();
-    MultiBase& exit() { for (auto& b: bases_) { b.exit(); } return *this; }
-private:
+    MultiBase &exit() {
+        for (auto &b : bases_) {
+            b.exit();
+        }
+        return *this;
+    }
+
+   private:
     std::atomic<int> id_;
     std::vector<EventBase> bases_;
 };
 
 //通道，封装了可以进行epoll的一个fd
-struct Channel: private noncopyable {
-    //base为事件管理器，fd为通道内部的fd，events为通道关心的事件
-    Channel(EventBase* base, int fd, int events);
+struct Channel : private noncopyable {
+    // base为事件管理器，fd为通道内部的fd，events为通道关心的事件
+    Channel(EventBase *base, int fd, int events);
     ~Channel();
-    EventBase* getBase() { return base_; }
+    EventBase *getBase() { return base_; }
     int fd() { return fd_; }
     //通道id
     int64_t id() { return id_; }
@@ -73,10 +82,10 @@ struct Channel: private noncopyable {
     void close();
 
     //挂接事件处理器
-    void onRead(const Task& readcb) { readcb_ = readcb; }
-    void onWrite(const Task& writecb) { writecb_ = writecb; }
-    void onRead(Task&& readcb) { readcb_ = std::move(readcb); }
-    void onWrite(Task&& writecb) { writecb_ = std::move(writecb); }
+    void onRead(const Task &readcb) { readcb_ = readcb; }
+    void onWrite(const Task &writecb) { writecb_ = writecb; }
+    void onRead(Task &&readcb) { readcb_ = std::move(readcb); }
+    void onWrite(Task &&writecb) { writecb_ = std::move(writecb); }
 
     //启用读写监听
     void enableRead(bool enable);
@@ -88,13 +97,14 @@ struct Channel: private noncopyable {
     //处理读写事件
     void handleRead() { readcb_(); }
     void handleWrite() { writecb_(); }
-protected:
-    EventBase* base_;
-    PollerBase* poller_;
+
+   protected:
+    EventBase *base_;
+    PollerBase *poller_;
     int fd_;
     short events_;
     int64_t id_;
     std::function<void()> readcb_, writecb_, errorcb_;
 };
 
-}
+}  // namespace handy

--- a/handy/file.cc
+++ b/handy/file.cc
@@ -1,21 +1,21 @@
 #include "file.h"
 #include <dirent.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 using namespace std;
 
 namespace handy {
 
-Status file::getContent(const std::string& filename, std::string& cont){
+Status file::getContent(const std::string &filename, std::string &cont) {
     int fd = open(filename.c_str(), O_RDONLY);
     if (fd < 0) {
         return Status::ioError("open", filename);
     }
-    ExitCaller ec1([=]{ close(fd); });
+    ExitCaller ec1([=] { close(fd); });
     char buf[4096];
-    for(;;) {
+    for (;;) {
         int r = read(fd, buf, sizeof buf);
         if (r < 0) {
             return Status::ioError("read", filename);
@@ -27,12 +27,12 @@ Status file::getContent(const std::string& filename, std::string& cont){
     return Status();
 }
 
-Status file::writeContent(const std::string& filename, const std::string& cont) {
-    int fd = open(filename.c_str(), O_WRONLY|O_CREAT|O_TRUNC, S_IRUSR | S_IWUSR);
+Status file::writeContent(const std::string &filename, const std::string &cont) {
+    int fd = open(filename.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (fd < 0) {
         return Status::ioError("open", filename);
     }
-    ExitCaller ec1([=]{ close(fd); });
+    ExitCaller ec1([=] { close(fd); });
     int r = write(fd, cont.data(), cont.size());
     if (r < 0) {
         return Status::ioError("write", filename);
@@ -40,7 +40,7 @@ Status file::writeContent(const std::string& filename, const std::string& cont) 
     return Status();
 }
 
-Status file::renameSave(const string& name, const string& tmpName, const string& cont) {
+Status file::renameSave(const string &name, const string &tmpName, const string &cont) {
     Status s = writeContent(tmpName, cont);
     if (s.ok()) {
         unlink(name.c_str());
@@ -49,13 +49,13 @@ Status file::renameSave(const string& name, const string& tmpName, const string&
     return s;
 }
 
-Status file::getChildren(const std::string& dir, std::vector<std::string>* result) {
+Status file::getChildren(const std::string &dir, std::vector<std::string> *result) {
     result->clear();
-    DIR* d = opendir(dir.c_str());
+    DIR *d = opendir(dir.c_str());
     if (d == NULL) {
         return Status::ioError("opendir", dir);
     }
-    struct dirent* entry;
+    struct dirent *entry;
     while ((entry = readdir(d)) != NULL) {
         result->push_back(entry->d_name);
     }
@@ -63,28 +63,28 @@ Status file::getChildren(const std::string& dir, std::vector<std::string>* resul
     return Status();
 }
 
-Status file::deleteFile(const string& fname) {
+Status file::deleteFile(const string &fname) {
     if (unlink(fname.c_str()) != 0) {
         return Status::ioError("unlink", fname);
     }
     return Status();
 }
 
-Status file::createDir(const std::string& name) {
+Status file::createDir(const std::string &name) {
     if (mkdir(name.c_str(), 0755) != 0) {
         return Status::ioError("mkdir", name);
     }
     return Status();
 }
 
-Status file::deleteDir(const std::string& name) {
+Status file::deleteDir(const std::string &name) {
     if (rmdir(name.c_str()) != 0) {
         return Status::ioError("rmdir", name);
     }
     return Status();
 }
 
-Status file::getFileSize(const std::string& fname, uint64_t* size) {
+Status file::getFileSize(const std::string &fname, uint64_t *size) {
     struct stat sbuf;
     if (stat(fname.c_str(), &sbuf) != 0) {
         *size = 0;
@@ -95,15 +95,15 @@ Status file::getFileSize(const std::string& fname, uint64_t* size) {
     return Status();
 }
 
-Status file::renameFile(const std::string& src, const std::string& target) {
+Status file::renameFile(const std::string &src, const std::string &target) {
     if (rename(src.c_str(), target.c_str()) != 0) {
         return Status::ioError("rename", src + " " + target);
     }
     return Status();
 }
 
-bool file::fileExists(const std::string& fname) {
+bool file::fileExists(const std::string &fname) {
     return access(fname.c_str(), F_OK) == 0;
 }
 
-}
+}  // namespace handy

--- a/handy/file.h
+++ b/handy/file.h
@@ -6,16 +6,16 @@
 namespace handy {
 
 struct file {
-    static Status getContent(const std::string& filename, std::string& cont);
-    static Status writeContent(const std::string& filename, const std::string& cont);
-    static Status renameSave(const std::string& name, const std::string& tmpName, const std::string& cont);
-    static Status getChildren(const std::string& dir, std::vector<std::string>* result);
-    static Status deleteFile(const std::string& fname);
-    static Status createDir(const std::string& name);
-    static Status deleteDir(const std::string& name);
-    static Status getFileSize(const std::string& fname, uint64_t* size);
-    static Status renameFile(const std::string& src, const std::string& target);
-    static bool fileExists(const std::string& fname);
+    static Status getContent(const std::string &filename, std::string &cont);
+    static Status writeContent(const std::string &filename, const std::string &cont);
+    static Status renameSave(const std::string &name, const std::string &tmpName, const std::string &cont);
+    static Status getChildren(const std::string &dir, std::vector<std::string> *result);
+    static Status deleteFile(const std::string &fname);
+    static Status createDir(const std::string &name);
+    static Status deleteDir(const std::string &name);
+    static Status getFileSize(const std::string &fname, uint64_t *size);
+    static Status renameFile(const std::string &src, const std::string &target);
+    static bool fileExists(const std::string &fname);
 };
 
-}
+}  // namespace handy

--- a/handy/handy-imp.h
+++ b/handy/handy-imp.h
@@ -1,13 +1,13 @@
 #pragma once
+#include <unistd.h>
+#include <memory>
+#include <set>
+#include <utility>
+#include "codec.h"
 #include "logging.h"
-#include "util.h"
 #include "net.h"
 #include "threads.h"
-#include "codec.h"
-#include <utility>
-#include <set>
-#include <memory>
-#include <unistd.h>
+#include "util.h"
 
 namespace handy {
 struct Channel;
@@ -19,18 +19,22 @@ struct EventBase;
 typedef std::unique_ptr<IdleIdImp> IdleId;
 typedef std::pair<int64_t, int64_t> TimerId;
 
-struct AutoContext: noncopyable {
-    void* ctx;
+struct AutoContext : noncopyable {
+    void *ctx;
     Task ctxDel;
-    AutoContext():ctx(0) {}
-    template<class T> T& context() {
+    AutoContext() : ctx(0) {}
+    template <class T>
+    T &context() {
         if (ctx == NULL) {
             ctx = new T();
-            ctxDel = [this] { delete (T*)ctx; };
+            ctxDel = [this] { delete (T *) ctx; };
         }
-        return *(T*)ctx;
+        return *(T *) ctx;
     }
-    ~AutoContext() { if (ctx) ctxDel(); }
+    ~AutoContext() {
+        if (ctx)
+            ctxDel();
+    }
 };
 
-}
+}  // namespace handy

--- a/handy/handy.h
+++ b/handy/handy.h
@@ -5,5 +5,5 @@
 #include "logging.h"
 #include "slice.h"
 #include "threads.h"
-#include "util.h"
 #include "udp.h"
+#include "util.h"

--- a/handy/http.cc
+++ b/handy/http.cc
@@ -1,14 +1,14 @@
 #include "http.h"
 #include "file.h"
-#include "status.h"
 #include "logging.h"
+#include "status.h"
 
 using namespace std;
 
 namespace handy {
 
-void HttpMsg::clear() { 
-    headers.clear(); 
+void HttpMsg::clear() {
+    headers.clear();
     version = "HTTP/1.1";
     body.clear();
     body2.clear();
@@ -17,28 +17,27 @@ void HttpMsg::clear() {
     scanned_ = 0;
 }
 
-
-string HttpMsg::getValueFromMap_(map<string, string>& m, const string& n) {
+string HttpMsg::getValueFromMap_(map<string, string> &m, const string &n) {
     auto p = m.find(n);
     return p == m.end() ? "" : p->second;
 }
 
-HttpMsg::Result HttpMsg::tryDecode_(Slice buf, bool copyBody, Slice* line1) {
+HttpMsg::Result HttpMsg::tryDecode_(Slice buf, bool copyBody, Slice *line1) {
     if (complete_) {
         return Complete;
     }
     if (!contentLen_) {
-        const char* p = buf.begin();
+        const char *p = buf.begin();
         Slice req;
-        //scanned at most points to first <cr> when empty line
+        // scanned at most points to first <cr> when empty line
         while (buf.size() >= scanned_ + 4) {
-            if (p[scanned_] == '\r' && memcmp(p+scanned_, "\r\n\r\n", 4) == 0) {
-                req = Slice(p, p+scanned_);
+            if (p[scanned_] == '\r' && memcmp(p + scanned_, "\r\n\r\n", 4) == 0) {
+                req = Slice(p, p + scanned_);
                 break;
             }
             scanned_++;
         }
-        if (req.empty()) { // header not complete
+        if (req.empty()) {  // header not complete
             return NotComplete;
         }
 
@@ -50,13 +49,13 @@ HttpMsg::Result HttpMsg::tryDecode_(Slice buf, bool copyBody, Slice* line1) {
             ln.trimSpace();
             if (k.size() && ln.size() && k.back() == ':') {
                 for (size_t i = 0; i < k.size(); i++) {
-                    ((char*)k.data())[i] = tolower(k[i]);
+                    ((char *) k.data())[i] = tolower(k[i]);
                 }
                 headers[k.sub(0, -1)] = ln;
             } else if (k.empty() && ln.empty() && req.empty()) {
                 break;
             } else {
-                error("bad http line: %.*s %.*s", (int)k.size(), k.data(), (int)ln.size(), ln.data());
+                error("bad http line: %.*s %.*s", (int) k.size(), k.data(), (int) ln.size(), ln.data());
                 return Error;
             }
         }
@@ -78,12 +77,12 @@ HttpMsg::Result HttpMsg::tryDecode_(Slice buf, bool copyBody, Slice* line1) {
     return complete_ ? Complete : NotComplete;
 }
 
-int HttpRequest::encode(Buffer& buf) {
+int HttpRequest::encode(Buffer &buf) {
     size_t osz = buf.size();
     char conlen[1024], reqln[4096];
     snprintf(reqln, sizeof reqln, "%s %s %s\n\n", method.c_str(), query_uri.c_str(), version.c_str());
     buf.append(reqln);
-    for (auto& hd: headers) {
+    for (auto &hd : headers) {
         buf.append(hd.first).append(": ").append(hd.second).append("\r\n");
     }
     buf.append("Connection: Keep-Alive\r\n");
@@ -101,26 +100,29 @@ HttpMsg::Result HttpRequest::tryDecode(Slice buf, bool copyBody) {
         query_uri = ln1.eatWord();
         version = ln1.eatWord();
         if (query_uri.size() == 0 || query_uri[0] != '/') {
-            error("query uri '%.*s' should begin with /", (int)query_uri.size(), query_uri.data());
+            error("query uri '%.*s' should begin with /", (int) query_uri.size(), query_uri.data());
             return Error;
         }
         for (size_t i = 0; i <= query_uri.size(); i++) {
             if (query_uri[i] == '?') {
                 uri = Slice(query_uri.data(), i);
-                Slice qs = Slice(query_uri.data()+i+1, query_uri.size()-i-1);
+                Slice qs = Slice(query_uri.data() + i + 1, query_uri.size() - i - 1);
                 size_t c, kb, ke, vb, ve;
                 ve = vb = ke = kb = c = 0;
                 while (c < qs.size()) {
-                    while (c < qs.size() && qs[c] != '=' && qs[c] != '&') c++;
+                    while (c < qs.size() && qs[c] != '=' && qs[c] != '&')
+                        c++;
                     ke = c;
-                    if (c < qs.size() && qs[c] == '=') c++;
+                    if (c < qs.size() && qs[c] == '=')
+                        c++;
                     vb = c;
-                    while (c < qs.size() && qs[c] != '&') c++;
+                    while (c < qs.size() && qs[c] != '&')
+                        c++;
                     ve = c;
-                    if (c < qs.size() && qs[c] == '&') c++;
+                    if (c < qs.size() && qs[c] == '&')
+                        c++;
                     if (kb != ke) {
-                        args[string(qs.data()+kb, qs.data()+ke)] =
-                            string(qs.data()+vb, qs.data()+ve);
+                        args[string(qs.data() + kb, qs.data() + ke)] = string(qs.data() + vb, qs.data() + ve);
                     }
                     ve = vb = ke = kb = c;
                 }
@@ -134,13 +136,12 @@ HttpMsg::Result HttpRequest::tryDecode(Slice buf, bool copyBody) {
     return r;
 }
 
-int HttpResponse::encode(Buffer& buf) {
+int HttpResponse::encode(Buffer &buf) {
     size_t osz = buf.size();
     char conlen[1024], statusln[1024];
-    snprintf(statusln, sizeof statusln, 
-        "%s %d %s\r\n", version.c_str(), status, statusWord.c_str());
+    snprintf(statusln, sizeof statusln, "%s %d %s\r\n", version.c_str(), status, statusWord.c_str());
     buf.append(statusln);
-    for (auto& hd: headers) {
+    for (auto &hd : headers) {
         buf.append(hd.first).append(": ").append(hd.second).append("\r\n");
     }
     buf.append("Connection: Keep-Alive\r\n");
@@ -152,7 +153,7 @@ int HttpResponse::encode(Buffer& buf) {
 
 HttpMsg::Result HttpResponse::tryDecode(Slice buf, bool copyBody) {
     Slice ln1;
-    Result r = tryDecode_(buf, copyBody, &ln1); 
+    Result r = tryDecode_(buf, copyBody, &ln1);
     if (ln1.size()) {
         version = ln1.eatWord();
         status = atoi(ln1.eatWord().data());
@@ -161,10 +162,10 @@ HttpMsg::Result HttpResponse::tryDecode(Slice buf, bool copyBody) {
     return r;
 }
 
-void HttpConnPtr::sendFile(const string& filename) const {
+void HttpConnPtr::sendFile(const string &filename) const {
     string cont;
     Status st = file::getContent(filename, cont);
-    HttpResponse& resp = getResponse();
+    HttpResponse &resp = getResponse();
     if (st.code() == ENOENT) {
         resp.setNotFound();
     } else if (st.code()) {
@@ -175,13 +176,16 @@ void HttpConnPtr::sendFile(const string& filename) const {
     sendResponse();
 }
 
-void HttpConnPtr::onHttpMsg(const HttpCallBack& cb) const {
-    tcp->onRead([cb](const TcpConnPtr& con) { HttpConnPtr hcon(con); hcon.handleRead(cb);});
+void HttpConnPtr::onHttpMsg(const HttpCallBack &cb) const {
+    tcp->onRead([cb](const TcpConnPtr &con) {
+        HttpConnPtr hcon(con);
+        hcon.handleRead(cb);
+    });
 }
 
-void HttpConnPtr::handleRead(const HttpCallBack& cb) const {
-    if (!tcp->isClient()) { //server
-        HttpRequest& req = getRequest();
+void HttpConnPtr::handleRead(const HttpCallBack &cb) const {
+    if (!tcp->isClient()) {  // server
+        HttpRequest &req = getRequest();
         HttpMsg::Result r = req.tryDecode(tcp->getInput());
         if (r == HttpMsg::Error) {
             tcp->close();
@@ -190,13 +194,12 @@ void HttpConnPtr::handleRead(const HttpCallBack& cb) const {
         if (r == HttpMsg::Continue100) {
             tcp->send("HTTP/1.1 100 Continue\n\r\n");
         } else if (r == HttpMsg::Complete) {
-            info("http request: %s %s %s", req.method.c_str(), 
-                req.query_uri.c_str(), req.version.c_str());
-            trace("http request:\n%.*s", (int)tcp->input_.size(), tcp->input_.data());
+            info("http request: %s %s %s", req.method.c_str(), req.query_uri.c_str(), req.version.c_str());
+            trace("http request:\n%.*s", (int) tcp->input_.size(), tcp->input_.data());
             cb(*this);
         }
     } else {
-        HttpResponse& resp = getResponse();
+        HttpResponse &resp = getResponse();
         HttpMsg::Result r = resp.tryDecode(tcp->getInput());
         if (r == HttpMsg::Error) {
             tcp->close();
@@ -204,42 +207,40 @@ void HttpConnPtr::handleRead(const HttpCallBack& cb) const {
         }
         if (r == HttpMsg::Complete) {
             info("http response: %d %s", resp.status, resp.statusWord.c_str());
-            trace("http response:\n%.*s", (int)tcp->input_.size(), tcp->input_.data());
+            trace("http response:\n%.*s", (int) tcp->input_.size(), tcp->input_.data());
             cb(tcp);
         }
     }
 }
 
-void HttpConnPtr::clearData() const { 
+void HttpConnPtr::clearData() const {
     if (tcp->isClient()) {
-        tcp->getInput().consume(getResponse().getByte()); 
-        getResponse().clear(); 
+        tcp->getInput().consume(getResponse().getByte());
+        getResponse().clear();
     } else {
         tcp->getInput().consume(getRequest().getByte());
-        getRequest().clear(); 
+        getRequest().clear();
     }
 }
 
-void HttpConnPtr::logOutput(const char* title) const {
-    Buffer& o = tcp->getOutput();
-    trace("%s:\n%.*s", title, (int)o.size(), o.data());
+void HttpConnPtr::logOutput(const char *title) const {
+    Buffer &o = tcp->getOutput();
+    trace("%s:\n%.*s", title, (int) o.size(), o.data());
 }
 
-HttpServer::HttpServer(EventBases* bases):
-TcpServer(bases)
-{
-    defcb_ = [](const HttpConnPtr& con) {
-        HttpResponse& resp = con.getResponse();
+HttpServer::HttpServer(EventBases *bases) : TcpServer(bases) {
+    defcb_ = [](const HttpConnPtr &con) {
+        HttpResponse &resp = con.getResponse();
         resp.status = 404;
         resp.statusWord = "Not Found";
         resp.body = "Not Found";
         con.sendResponse();
     };
-    conncb_ = []{ return TcpConnPtr(new TcpConn); };
+    conncb_ = [] { return TcpConnPtr(new TcpConn); };
     onConnCreate([this]() {
         HttpConnPtr hcon(conncb_());
-        hcon.onHttpMsg([this](const HttpConnPtr& hcon) {
-            HttpRequest& req = hcon.getRequest();
+        hcon.onHttpMsg([this](const HttpConnPtr &hcon) {
+            HttpRequest &req = hcon.getRequest();
             auto p = cbs_.find(req.method);
             if (p != cbs_.end()) {
                 auto p2 = p->second.find(req.uri);
@@ -254,4 +255,4 @@ TcpServer(bases)
     });
 }
 
-}
+}  // namespace handy

--- a/handy/http.h
+++ b/handy/http.h
@@ -1,110 +1,144 @@
 #pragma once
 
-#include "slice.h"
-#include "conn.h"
 #include <map>
+#include "conn.h"
+#include "slice.h"
 
 namespace handy {
 
-//base class for HttpRequest and HttpResponse
+// base class for HttpRequest and HttpResponse
 struct HttpMsg {
-    enum Result{ Error, Complete, NotComplete, Continue100, };
+    enum Result {
+        Error,
+        Complete,
+        NotComplete,
+        Continue100,
+    };
     HttpMsg() { HttpMsg::clear(); };
 
     //内容添加到buf，返回写入的字节数
-    virtual int encode(Buffer& buf)=0;
+    virtual int encode(Buffer &buf) = 0;
     //尝试从buf中解析，默认复制body内容
-    virtual Result tryDecode(Slice buf, bool copyBody=true)=0;
+    virtual Result tryDecode(Slice buf, bool copyBody = true) = 0;
     //清空消息相关的字段
     virtual void clear();
 
     std::map<std::string, std::string> headers;
     std::string version, body;
-    //body可能较大，为了避免数据复制，加入body2
+    // body可能较大，为了避免数据复制，加入body2
     Slice body2;
 
-    std::string getHeader(const std::string& n) { return getValueFromMap_(headers, n); }
-    Slice getBody() { return body2.size() ? body2 : (Slice)body; }
+    std::string getHeader(const std::string &n) { return getValueFromMap_(headers, n); }
+    Slice getBody() { return body2.size() ? body2 : (Slice) body; }
 
     //如果tryDecode返回Complete，则返回已解析的字节数
     int getByte() { return scanned_; }
-protected:
+
+   protected:
     bool complete_;
     size_t contentLen_;
     size_t scanned_;
-    Result tryDecode_(Slice buf, bool copyBody, Slice* line1);
-    std::string getValueFromMap_(std::map<std::string, std::string>& m, const std::string& n);
+    Result tryDecode_(Slice buf, bool copyBody, Slice *line1);
+    std::string getValueFromMap_(std::map<std::string, std::string> &m, const std::string &n);
 };
 
-struct HttpRequest: public HttpMsg {
+struct HttpRequest : public HttpMsg {
     HttpRequest() { clear(); }
     std::map<std::string, std::string> args;
     std::string method, uri, query_uri;
-    std::string getArg(const std::string& n) { return getValueFromMap_(args, n); }
+    std::string getArg(const std::string &n) { return getValueFromMap_(args, n); }
 
-    //override
-    virtual int encode(Buffer& buf);
-    virtual Result tryDecode(Slice buf, bool copyBody=true);
-    virtual void clear() { HttpMsg::clear(); args.clear(); method = "GET"; query_uri = uri = ""; }
+    // override
+    virtual int encode(Buffer &buf);
+    virtual Result tryDecode(Slice buf, bool copyBody = true);
+    virtual void clear() {
+        HttpMsg::clear();
+        args.clear();
+        method = "GET";
+        query_uri = uri = "";
+    }
 };
 
-struct HttpResponse: public HttpMsg {
+struct HttpResponse : public HttpMsg {
     HttpResponse() { clear(); }
     std::string statusWord;
     int status;
     void setNotFound() { setStatus(404, "Not Found"); }
-    void setStatus(int st, const std::string& msg="") { status = st; statusWord = msg; body = msg; }
+    void setStatus(int st, const std::string &msg = "") {
+        status = st;
+        statusWord = msg;
+        body = msg;
+    }
 
-    //override
-    virtual int encode(Buffer& buf);
-    virtual Result tryDecode(Slice buf, bool copyBody=true);
-    virtual void clear() { HttpMsg::clear(); status = 200; statusWord = "OK"; }
+    // override
+    virtual int encode(Buffer &buf);
+    virtual Result tryDecode(Slice buf, bool copyBody = true);
+    virtual void clear() {
+        HttpMsg::clear();
+        status = 200;
+        statusWord = "OK";
+    }
 };
 
-//Http连接本质上是一条Tcp连接，下面的封装主要是加入了HttpRequest，HttpResponse的处理
+// Http连接本质上是一条Tcp连接，下面的封装主要是加入了HttpRequest，HttpResponse的处理
 struct HttpConnPtr {
     TcpConnPtr tcp;
-    HttpConnPtr(const TcpConnPtr& con):tcp(con) {}
+    HttpConnPtr(const TcpConnPtr &con) : tcp(con) {}
     operator TcpConnPtr() const { return tcp; }
-    TcpConn* operator ->() const { return tcp.get(); }
-    bool operator < (const HttpConnPtr& con) const { return tcp < con.tcp; }
+    TcpConn *operator->() const { return tcp.get(); }
+    bool operator<(const HttpConnPtr &con) const { return tcp < con.tcp; }
 
-    typedef std::function<void(const HttpConnPtr&)> HttpCallBack;
+    typedef std::function<void(const HttpConnPtr &)> HttpCallBack;
 
-    HttpRequest& getRequest() const { return tcp->internalCtx_.context<HttpContext>().req; }
-    HttpResponse& getResponse() const { return tcp->internalCtx_.context<HttpContext>().resp; }
+    HttpRequest &getRequest() const { return tcp->internalCtx_.context<HttpContext>().req; }
+    HttpResponse &getResponse() const { return tcp->internalCtx_.context<HttpContext>().resp; }
 
     void sendRequest() const { sendRequest(getRequest()); }
     void sendResponse() const { sendResponse(getResponse()); }
-    void sendRequest(HttpRequest& req) const { req.encode(tcp->getOutput()); logOutput("http req"); clearData(); tcp->sendOutput(); }
-    void sendResponse(HttpResponse& resp) const { resp.encode(tcp->getOutput()); logOutput("http resp"); clearData(); tcp->sendOutput(); }
+    void sendRequest(HttpRequest &req) const {
+        req.encode(tcp->getOutput());
+        logOutput("http req");
+        clearData();
+        tcp->sendOutput();
+    }
+    void sendResponse(HttpResponse &resp) const {
+        resp.encode(tcp->getOutput());
+        logOutput("http resp");
+        clearData();
+        tcp->sendOutput();
+    }
     //文件作为Response
-    void sendFile(const std::string& filename) const;
+    void sendFile(const std::string &filename) const;
     void clearData() const;
 
-    void onHttpMsg(const HttpCallBack& cb) const;
-protected:
+    void onHttpMsg(const HttpCallBack &cb) const;
+
+   protected:
     struct HttpContext {
         HttpRequest req;
         HttpResponse resp;
     };
-    void handleRead(const HttpCallBack& cb) const;
-    void logOutput(const char* title) const;
+    void handleRead(const HttpCallBack &cb) const;
+    void logOutput(const char *title) const;
 };
 
 typedef HttpConnPtr::HttpCallBack HttpCallBack;
 
-//http服务器
-struct HttpServer: public TcpServer {
-    HttpServer(EventBases* base);
-    template <class Conn=TcpConn> void setConnType() { conncb_ = []{ return TcpConnPtr(new Conn); }; }
-    void onGet(const std::string& uri, const HttpCallBack& cb) { cbs_["GET"][uri] = cb; }
-    void onRequest(const std::string& method, const std::string& uri, const HttpCallBack& cb) { cbs_[method][uri] = cb; }
-    void onDefault(const HttpCallBack& cb) { defcb_ = cb; }
-private:
+// http服务器
+struct HttpServer : public TcpServer {
+    HttpServer(EventBases *base);
+    template <class Conn = TcpConn>
+    void setConnType() {
+        conncb_ = [] { return TcpConnPtr(new Conn); };
+    }
+    void onGet(const std::string &uri, const HttpCallBack &cb) { cbs_["GET"][uri] = cb; }
+    void onRequest(const std::string &method, const std::string &uri, const HttpCallBack &cb) { cbs_[method][uri] = cb; }
+    void onDefault(const HttpCallBack &cb) { defcb_ = cb; }
+
+   private:
     HttpCallBack defcb_;
     std::function<TcpConnPtr()> conncb_;
     std::map<std::string, std::map<std::string, HttpCallBack>> cbs_;
 };
 
-}
+}  // namespace handy

--- a/handy/logging.cc
+++ b/handy/logging.cc
@@ -1,25 +1,24 @@
 #include "logging.h"
 #include <assert.h>
-#include <sys/time.h>
-#include <sys/types.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
-#include <fcntl.h>
-#include <time.h>
-#include <utility>
-#include <stdarg.h>
-#include <unistd.h>
-#include <errno.h>
-#include <string.h>
+#include <sys/time.h>
+#include <sys/types.h>
 #include <syslog.h>
+#include <time.h>
+#include <unistd.h>
+#include <utility>
 #include "port_posix.h"
 
 using namespace std;
 
 namespace handy {
 
-
-Logger::Logger(): level_(LINFO), lastRotate_(time(NULL)), rotateInterval_(86400) {
+Logger::Logger() : level_(LINFO), lastRotate_(time(NULL)), rotateInterval_(86400) {
     tzset();
     fd_ = -1;
     realRotate_ = lastRotate_;
@@ -31,38 +30,30 @@ Logger::~Logger() {
     }
 }
 
-const char* Logger::levelStrs_[LALL+1] = {
-    "FATAL",
-    "ERROR",
-    "UERR",
-    "WARN",
-    "INFO",
-    "DEBUG",
-    "TRACE",
-    "ALL",
+const char *Logger::levelStrs_[LALL + 1] = {
+    "FATAL", "ERROR", "UERR", "WARN", "INFO", "DEBUG", "TRACE", "ALL",
 };
 
-Logger& Logger::getLogger() {
+Logger &Logger::getLogger() {
     static Logger logger;
     return logger;
 }
 
-void Logger::setLogLevel(const string& level) {
+void Logger::setLogLevel(const string &level) {
     LogLevel ilevel = LINFO;
-    for (size_t i = 0; i < sizeof(levelStrs_)/sizeof(const char*); i++) {
+    for (size_t i = 0; i < sizeof(levelStrs_) / sizeof(const char *); i++) {
         if (strcasecmp(levelStrs_[i], level.c_str()) == 0) {
-            ilevel = (LogLevel)i;
+            ilevel = (LogLevel) i;
             break;
         }
     }
     setLogLevel(ilevel);
 }
 
-void Logger::setFileName(const string& filename) {
-    int fd = open(filename.c_str(), O_APPEND|O_CREAT|O_WRONLY|O_CLOEXEC, DEFFILEMODE);
+void Logger::setFileName(const string &filename) {
+    int fd = open(filename.c_str(), O_APPEND | O_CREAT | O_WRONLY | O_CLOEXEC, DEFFILEMODE);
     if (fd < 0) {
-        fprintf(stderr, "open log file %s failed. msg: %s ignored\n",
-                filename.c_str(), strerror(errno));
+        fprintf(stderr, "open log file %s failed. msg: %s ignored\n", filename.c_str(), strerror(errno));
         return;
     }
     filename_ = filename;
@@ -70,14 +61,14 @@ void Logger::setFileName(const string& filename) {
         fd_ = fd;
     } else {
         int r = dup2(fd, fd_);
-        fatalif(r<0, "dup2 failed");
+        fatalif(r < 0, "dup2 failed");
         close(fd);
     }
 }
 
 void Logger::maybeRotate() {
     time_t now = time(NULL);
-    if (filename_.empty() || (now - timezone) / rotateInterval_ == (lastRotate_ - timezone)/ rotateInterval_) {
+    if (filename_.empty() || (now - timezone) / rotateInterval_ == (lastRotate_ - timezone) / rotateInterval_) {
         return;
     }
     lastRotate_ = now;
@@ -89,20 +80,16 @@ void Logger::maybeRotate() {
     struct tm ntm;
     localtime_r(&now, &ntm);
     char newname[4096];
-    snprintf(newname, sizeof(newname), "%s.%d%02d%02d%02d%02d",
-        filename_.c_str(), ntm.tm_year + 1900, ntm.tm_mon + 1, ntm.tm_mday,
-        ntm.tm_hour, ntm.tm_min);
-    const char* oldname = filename_.c_str();
+    snprintf(newname, sizeof(newname), "%s.%d%02d%02d%02d%02d", filename_.c_str(), ntm.tm_year + 1900, ntm.tm_mon + 1, ntm.tm_mday, ntm.tm_hour, ntm.tm_min);
+    const char *oldname = filename_.c_str();
     int err = rename(oldname, newname);
     if (err != 0) {
-        fprintf(stderr, "rename logfile %s -> %s failed msg: %s\n",
-            oldname, newname, strerror(errno));
+        fprintf(stderr, "rename logfile %s -> %s failed msg: %s\n", oldname, newname, strerror(errno));
         return;
     }
     int fd = open(filename_.c_str(), O_APPEND | O_CREAT | O_WRONLY | O_CLOEXEC, DEFFILEMODE);
     if (fd < 0) {
-        fprintf(stderr, "open log file %s failed. msg: %s ignored\n",
-            newname, strerror(errno));
+        fprintf(stderr, "open log file %s failed. msg: %s ignored\n", newname, strerror(errno));
         return;
     }
     dup2(fd, fd_);
@@ -110,7 +97,7 @@ void Logger::maybeRotate() {
 }
 
 static thread_local uint64_t tid;
-void Logger::logv(int level, const char* file, int line, const char* func, const char* fmt ...) {
+void Logger::logv(int level, const char *file, int line, const char *func, const char *fmt...) {
     if (tid == 0) {
         tid = port::gettid();
     }
@@ -118,46 +105,34 @@ void Logger::logv(int level, const char* file, int line, const char* func, const
         return;
     }
     maybeRotate();
-    char buffer[4*1024];
-    char* p = buffer;
-    char* limit = buffer + sizeof(buffer);
+    char buffer[4 * 1024];
+    char *p = buffer;
+    char *limit = buffer + sizeof(buffer);
 
     struct timeval now_tv;
     gettimeofday(&now_tv, NULL);
     const time_t seconds = now_tv.tv_sec;
     struct tm t;
     localtime_r(&seconds, &t);
-    p += snprintf(p, limit - p,
-        "%04d/%02d/%02d-%02d:%02d:%02d.%06d %lx %s %s:%d ",
-        t.tm_year + 1900,
-        t.tm_mon + 1,
-        t.tm_mday,
-        t.tm_hour,
-        t.tm_min,
-        t.tm_sec,
-        static_cast<int>(now_tv.tv_usec),
-        (long)tid,
-        levelStrs_[level],
-        file,
-        line);
+    p += snprintf(p, limit - p, "%04d/%02d/%02d-%02d:%02d:%02d.%06d %lx %s %s:%d ", t.tm_year + 1900, t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec,
+                  static_cast<int>(now_tv.tv_usec), (long) tid, levelStrs_[level], file, line);
     va_list args;
     va_start(args, fmt);
-    p += vsnprintf(p, limit-p, fmt, args);
+    p += vsnprintf(p, limit - p, fmt, args);
     va_end(args);
     p = std::min(p, limit - 2);
-    //trim the ending \n
+    // trim the ending \n
     while (*--p == '\n') {
     }
     *++p = '\n';
     *++p = '\0';
     int fd = fd_ == -1 ? 1 : fd_;
     int err = ::write(fd, buffer, p - buffer);
-    if (err != p-buffer) {
-        fprintf(stderr, "write log file %s failed. written %d errmsg: %s\n",
-            filename_.c_str(), err, strerror(errno));
+    if (err != p - buffer) {
+        fprintf(stderr, "write log file %s failed. written %d errmsg: %s\n", filename_.c_str(), err, strerror(errno));
     }
     if (level <= LERROR) {
-        syslog(LOG_ERR, "%s", buffer+27);
+        syslog(LOG_ERR, "%s", buffer + 27);
     }
     if (level == LFATAL) {
         fprintf(stderr, "%s", buffer);
@@ -165,4 +140,4 @@ void Logger::logv(int level, const char* file, int line, const char* func, const
     }
 }
 
-}
+}  // namespace handy

--- a/handy/logging.h
+++ b/handy/logging.h
@@ -1,24 +1,24 @@
-#pragma  once
-#include <string>
+#pragma once
 #include <stdio.h>
 #include <atomic>
+#include <string>
 #include "util.h"
 
 #ifdef NDEBUG
-#define hlog(level, ...) \
-    do { \
-        if (level<=Logger::getLogger().getLogLevel()) { \
+#define hlog(level, ...)                                                                \
+    do {                                                                                \
+        if (level <= Logger::getLogger().getLogLevel()) {                               \
             Logger::getLogger().logv(level, __FILE__, __LINE__, __func__, __VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                                               \
+    } while (0)
 #else
-#define hlog(level, ...) \
-    do { \
-        if (level<=Logger::getLogger().getLogLevel()) { \
-            snprintf(0, 0, __VA_ARGS__); \
+#define hlog(level, ...)                                                                \
+    do {                                                                                \
+        if (level <= Logger::getLogger().getLogLevel()) {                               \
+            snprintf(0, 0, __VA_ARGS__);                                                \
             Logger::getLogger().logv(level, __FILE__, __LINE__, __func__, __VA_ARGS__); \
-        } \
-    } while(0)
+        }                                                                               \
+    } while (0)
 
 #endif
 
@@ -28,35 +28,52 @@
 #define warn(...) hlog(Logger::LWARN, __VA_ARGS__)
 #define error(...) hlog(Logger::LERROR, __VA_ARGS__)
 #define fatal(...) hlog(Logger::LFATAL, __VA_ARGS__)
-#define fatalif(b, ...) do { if((b)) { hlog(Logger::LFATAL, __VA_ARGS__); } } while (0)
-#define check(b, ...) do { if((b)) { hlog(Logger::LFATAL, __VA_ARGS__); } } while (0)
-#define exitif(b, ...) do { if ((b)) { hlog(Logger::LERROR, __VA_ARGS__); _exit(1); }} while(0)
+#define fatalif(b, ...)                        \
+    do {                                       \
+        if ((b)) {                             \
+            hlog(Logger::LFATAL, __VA_ARGS__); \
+        }                                      \
+    } while (0)
+#define check(b, ...)                          \
+    do {                                       \
+        if ((b)) {                             \
+            hlog(Logger::LFATAL, __VA_ARGS__); \
+        }                                      \
+    } while (0)
+#define exitif(b, ...)                         \
+    do {                                       \
+        if ((b)) {                             \
+            hlog(Logger::LERROR, __VA_ARGS__); \
+            _exit(1);                          \
+        }                                      \
+    } while (0)
 
 #define setloglevel(l) Logger::getLogger().setLogLevel(l)
 #define setlogfile(n) Logger::getLogger().setFileName(n)
 
 namespace handy {
 
-struct Logger: private noncopyable {
-    enum LogLevel{LFATAL=0, LERROR, LUERR, LWARN, LINFO, LDEBUG, LTRACE, LALL};
+struct Logger : private noncopyable {
+    enum LogLevel { LFATAL = 0, LERROR, LUERR, LWARN, LINFO, LDEBUG, LTRACE, LALL };
     Logger();
     ~Logger();
-    void logv(int level, const char* file, int line, const char* func, const char* fmt ...);
+    void logv(int level, const char *file, int line, const char *func, const char *fmt...);
 
-    void setFileName(const std::string& filename);
-    void setLogLevel(const std::string& level);
+    void setFileName(const std::string &filename);
+    void setLogLevel(const std::string &level);
     void setLogLevel(LogLevel level) { level_ = std::min(LALL, std::max(LFATAL, level)); }
 
     LogLevel getLogLevel() { return level_; }
-    const char* getLogLevelStr() { return levelStrs_[level_]; }
+    const char *getLogLevelStr() { return levelStrs_[level_]; }
     int getFd() { return fd_; }
 
-    void adjustLogLevel(int adjust) { setLogLevel(LogLevel(level_+adjust)); }
+    void adjustLogLevel(int adjust) { setLogLevel(LogLevel(level_ + adjust)); }
     void setRotateInterval(long rotateInterval) { rotateInterval_ = rotateInterval; }
-    static Logger& getLogger();
-private:
+    static Logger &getLogger();
+
+   private:
     void maybeRotate();
-    static const char* levelStrs_[LALL+1];
+    static const char *levelStrs_[LALL + 1];
     int fd_;
     LogLevel level_;
     long lastRotate_;
@@ -65,5 +82,4 @@ private:
     std::string filename_;
 };
 
-}
-
+}  // namespace handy

--- a/handy/net.cc
+++ b/handy/net.cc
@@ -1,11 +1,11 @@
 #include "net.h"
-#include "util.h"
-#include "logging.h"
-#include <netinet/tcp.h>
-#include <fcntl.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <string>
+#include "logging.h"
+#include "util.h"
 
 using namespace std;
 namespace handy {
@@ -44,7 +44,7 @@ int net::setNoDelay(int fd, bool value) {
     return setsockopt(fd, SOL_SOCKET, TCP_NODELAY, &flag, len);
 }
 
-Ip4Addr::Ip4Addr(const string& host, short port) {
+Ip4Addr::Ip4Addr(const string &host, short port) {
     memset(&addr_, 0, sizeof addr_);
     addr_.sin_family = AF_INET;
     addr_.sin_port = htons(port);
@@ -53,42 +53,33 @@ Ip4Addr::Ip4Addr(const string& host, short port) {
     } else {
         addr_.sin_addr.s_addr = INADDR_ANY;
     }
-    if (addr_.sin_addr.s_addr == INADDR_NONE){
+    if (addr_.sin_addr.s_addr == INADDR_NONE) {
         error("cannot resove %s to ip", host.c_str());
     }
 }
 
 string Ip4Addr::toString() const {
     uint32_t uip = addr_.sin_addr.s_addr;
-    return util::format("%d.%d.%d.%d:%d",
-        (uip >> 0)&0xff,
-        (uip >> 8)&0xff,
-        (uip >> 16)&0xff,
-        (uip >> 24)&0xff,
-        ntohs(addr_.sin_port));
+    return util::format("%d.%d.%d.%d:%d", (uip >> 0) & 0xff, (uip >> 8) & 0xff, (uip >> 16) & 0xff, (uip >> 24) & 0xff, ntohs(addr_.sin_port));
 }
 
-string Ip4Addr::ip() const { 
+string Ip4Addr::ip() const {
     uint32_t uip = addr_.sin_addr.s_addr;
-    return util::format("%d.%d.%d.%d",
-        (uip >> 0)&0xff,
-        (uip >> 8)&0xff,
-        (uip >> 16)&0xff,
-        (uip >> 24)&0xff);
+    return util::format("%d.%d.%d.%d", (uip >> 0) & 0xff, (uip >> 8) & 0xff, (uip >> 16) & 0xff, (uip >> 24) & 0xff);
 }
 
 short Ip4Addr::port() const {
     return ntohs(addr_.sin_port);
 }
 
-unsigned int Ip4Addr::ipInt() const { 
+unsigned int Ip4Addr::ipInt() const {
     return ntohl(addr_.sin_addr.s_addr);
 }
 bool Ip4Addr::isIpValid() const {
     return addr_.sin_addr.s_addr != INADDR_NONE;
 }
 
-char* Buffer::makeRoom(size_t len) {
+char *Buffer::makeRoom(size_t len) {
     if (e_ + len <= cap_) {
     } else if (size() + len < cap_ / 2) {
         moveHead();
@@ -99,8 +90,8 @@ char* Buffer::makeRoom(size_t len) {
 }
 
 void Buffer::expand(size_t len) {
-    size_t ncap = std::max(exp_, std::max(2*cap_, size()+len));
-    char* p = new char[ncap];
+    size_t ncap = std::max(exp_, std::max(2 * cap_, size() + len));
+    char *p = new char[ncap];
     std::copy(begin(), end(), p);
     e_ -= b_;
     b_ = 0;
@@ -109,22 +100,22 @@ void Buffer::expand(size_t len) {
     cap_ = ncap;
 }
 
-void Buffer::copyFrom(const Buffer& b) {
-    memcpy(this, &b, sizeof b); 
+void Buffer::copyFrom(const Buffer &b) {
+    memcpy(this, &b, sizeof b);
     if (b.buf_) {
-        buf_ = new char[cap_]; 
+        buf_ = new char[cap_];
         memcpy(data(), b.begin(), b.size());
     }
 }
 
-Buffer& Buffer::absorb(Buffer& buf) { 
+Buffer &Buffer::absorb(Buffer &buf) {
     if (&buf != this) {
         if (size() == 0) {
             char b[sizeof buf];
             memcpy(b, this, sizeof b);
             memcpy(this, &buf, sizeof b);
             memcpy(&buf, b, sizeof b);
-            std::swap(exp_, buf.exp_); //keep the origin exp_
+            std::swap(exp_, buf.exp_);  // keep the origin exp_
         } else {
             append(buf.begin(), buf.size());
             buf.clear();
@@ -133,5 +124,4 @@ Buffer& Buffer::absorb(Buffer& buf) {
     return *this;
 }
 
-
-}
+}  // namespace handy

--- a/handy/net.h
+++ b/handy/net.h
@@ -1,68 +1,116 @@
 #pragma once
-#include <string.h>
 #include <netinet/in.h>
-#include <string>
+#include <string.h>
 #include <algorithm>
-#include "slice.h"
+#include <string>
 #include "port_posix.h"
+#include "slice.h"
 
 namespace handy {
 
 struct net {
-    template<class T> static T hton(T v) { return port::htobe(v); }
-    template<class T> static T ntoh(T v) { return port::htobe(v); }
-    static int setNonBlock(int fd, bool value=true);
-    static int setReuseAddr(int fd, bool value=true);
-    static int setReusePort(int fd, bool value=true);
-    static int setNoDelay(int fd, bool value=true);
+    template <class T>
+    static T hton(T v) {
+        return port::htobe(v);
+    }
+    template <class T>
+    static T ntoh(T v) {
+        return port::htobe(v);
+    }
+    static int setNonBlock(int fd, bool value = true);
+    static int setReuseAddr(int fd, bool value = true);
+    static int setReusePort(int fd, bool value = true);
+    static int setNoDelay(int fd, bool value = true);
 };
 
 struct Ip4Addr {
-    Ip4Addr(const std::string& host, short port);
-    Ip4Addr(short port=0): Ip4Addr("", port) {}
-    Ip4Addr(const struct sockaddr_in& addr): addr_(addr) {};
+    Ip4Addr(const std::string &host, short port);
+    Ip4Addr(short port = 0) : Ip4Addr("", port) {}
+    Ip4Addr(const struct sockaddr_in &addr) : addr_(addr){};
     std::string toString() const;
     std::string ip() const;
     short port() const;
     unsigned int ipInt() const;
-    //if you pass a hostname to constructor, then use this to check error
+    // if you pass a hostname to constructor, then use this to check error
     bool isIpValid() const;
-    struct sockaddr_in& getAddr() { return addr_; }
-    static std::string hostToIp(const std::string& host) { Ip4Addr addr(host, 0); return addr.ip(); }
-private:
+    struct sockaddr_in &getAddr() {
+        return addr_;
+    }
+    static std::string hostToIp(const std::string &host) {
+        Ip4Addr addr(host, 0);
+        return addr.ip();
+    }
+
+   private:
     struct sockaddr_in addr_;
 };
 
 struct Buffer {
-    Buffer(): buf_(NULL), b_(0), e_(0), cap_(0), exp_(512) {}
+    Buffer() : buf_(NULL), b_(0), e_(0), cap_(0), exp_(512) {}
     ~Buffer() { delete[] buf_; }
-    void clear() { delete[] buf_; buf_ = NULL; cap_ = 0; b_ = e_ = 0; }
+    void clear() {
+        delete[] buf_;
+        buf_ = NULL;
+        cap_ = 0;
+        b_ = e_ = 0;
+    }
     size_t size() const { return e_ - b_; }
-    bool empty() const  { return e_ == b_; }
-    char* data() const  { return buf_ + b_; }
-    char* begin() const  { return buf_ + b_; }
-    char* end() const  { return buf_ + e_; }
-    char* makeRoom(size_t len);
-    void makeRoom() { if (space() < exp_) expand(0);}
-    size_t space() const  { return cap_ - e_; }
+    bool empty() const { return e_ == b_; }
+    char *data() const { return buf_ + b_; }
+    char *begin() const { return buf_ + b_; }
+    char *end() const { return buf_ + e_; }
+    char *makeRoom(size_t len);
+    void makeRoom() {
+        if (space() < exp_)
+            expand(0);
+    }
+    size_t space() const { return cap_ - e_; }
     void addSize(size_t len) { e_ += len; }
-    char* allocRoom(size_t len) { char* p = makeRoom(len); addSize(len); return p; }
-    Buffer& append(const char* p, size_t len) { memcpy(allocRoom(len), p, len); return *this; }
-    Buffer& append(Slice slice) { return append(slice.data(), slice.size()); }
-    Buffer& append(const char* p) { return append(p, strlen(p)); }
-    template<class T> Buffer& appendValue(const T& v) { append((const char*)&v, sizeof v); return *this; }
-    Buffer& consume(size_t len) { b_ += len; if (size() == 0) clear(); return *this; }
-    Buffer& absorb(Buffer& buf);
+    char *allocRoom(size_t len) {
+        char *p = makeRoom(len);
+        addSize(len);
+        return p;
+    }
+    Buffer &append(const char *p, size_t len) {
+        memcpy(allocRoom(len), p, len);
+        return *this;
+    }
+    Buffer &append(Slice slice) { return append(slice.data(), slice.size()); }
+    Buffer &append(const char *p) { return append(p, strlen(p)); }
+    template <class T>
+    Buffer &appendValue(const T &v) {
+        append((const char *) &v, sizeof v);
+        return *this;
+    }
+    Buffer &consume(size_t len) {
+        b_ += len;
+        if (size() == 0)
+            clear();
+        return *this;
+    }
+    Buffer &absorb(Buffer &buf);
     void setSuggestSize(size_t sz) { exp_ = sz; }
-    Buffer(const Buffer& b) { copyFrom(b); }
-    Buffer& operator=(const Buffer& b) { if(this == &b) return *this; delete[] buf_; buf_ = NULL; copyFrom(b); return *this; }
-    operator Slice () { return Slice(data(), size()); }
-private:
-    char* buf_;
+    Buffer(const Buffer &b) { copyFrom(b); }
+    Buffer &operator=(const Buffer &b) {
+        if (this == &b)
+            return *this;
+        delete[] buf_;
+        buf_ = NULL;
+        copyFrom(b);
+        return *this;
+    }
+    operator Slice() { return Slice(data(), size()); }
+
+   private:
+    char *buf_;
     size_t b_, e_, cap_, exp_;
-    void moveHead() { std::copy(begin(), end(), buf_); e_ -= b_; b_ = 0; }
+    void moveHead() {
+        std::copy(begin(), end(), buf_);
+        e_ -= b_;
+        b_ = 0;
+    }
     void expand(size_t len);
-    void copyFrom(const Buffer& b);
+    void copyFrom(const Buffer &b);
 };
 
-}
+}  // namespace handy

--- a/handy/poller.cc
+++ b/handy/poller.cc
@@ -1,9 +1,9 @@
+#include <fcntl.h>
+#include "conn.h"
 #include "event_base.h"
 #include "logging.h"
 #include "util.h"
-#include <fcntl.h>
 #include "poller.h"
-#include "conn.h"
 
 #ifdef OS_LINUX
 #include <sys/epoll.h>
@@ -13,29 +13,30 @@
 #error "platform unsupported"
 #endif
 
-
 namespace handy {
 
 #ifdef OS_LINUX
 
-struct PollerEpoll : public PollerBase{
+struct PollerEpoll : public PollerBase {
     int fd_;
-    std::set<Channel*> liveChannels_;
-    //for epoll selected active events
+    std::set<Channel *> liveChannels_;
+    // for epoll selected active events
     struct epoll_event activeEvs_[kMaxEvents];
     PollerEpoll();
     ~PollerEpoll();
-    void addChannel(Channel* ch) override;
-    void removeChannel(Channel* ch) override;
-    void updateChannel(Channel* ch) override;
+    void addChannel(Channel *ch) override;
+    void removeChannel(Channel *ch) override;
+    void updateChannel(Channel *ch) override;
     void loop_once(int waitMs) override;
 };
 
-PollerBase* createPoller() { return new PollerEpoll(); }
+PollerBase *createPoller() {
+    return new PollerEpoll();
+}
 
-PollerEpoll::PollerEpoll(){
+PollerEpoll::PollerEpoll() {
     fd_ = epoll_create1(EPOLL_CLOEXEC);
-    fatalif(fd_<0, "epoll_create error %d %s", errno, strerror(errno));
+    fatalif(fd_ < 0, "epoll_create error %d %s", errno, strerror(errno));
     info("poller epoll %d created", fd_);
 }
 
@@ -48,32 +49,31 @@ PollerEpoll::~PollerEpoll() {
     info("poller %d destroyed", fd_);
 }
 
-void PollerEpoll::addChannel(Channel* ch) {
+void PollerEpoll::addChannel(Channel *ch) {
     struct epoll_event ev;
     memset(&ev, 0, sizeof(ev));
     ev.events = ch->events();
     ev.data.ptr = ch;
-    trace("adding channel %lld fd %d events %d epoll %d", (long long)ch->id(), ch->fd(), ev.events, fd_);
+    trace("adding channel %lld fd %d events %d epoll %d", (long long) ch->id(), ch->fd(), ev.events, fd_);
     int r = epoll_ctl(fd_, EPOLL_CTL_ADD, ch->fd(), &ev);
     fatalif(r, "epoll_ctl add failed %d %s", errno, strerror(errno));
     liveChannels_.insert(ch);
 }
 
-void PollerEpoll::updateChannel(Channel* ch) {
+void PollerEpoll::updateChannel(Channel *ch) {
     struct epoll_event ev;
     memset(&ev, 0, sizeof(ev));
     ev.events = ch->events();
     ev.data.ptr = ch;
-    trace("modifying channel %lld fd %d events read %d write %d epoll %d",
-          (long long)ch->id(), ch->fd(), ev.events & POLLIN, ev.events & POLLOUT, fd_);
+    trace("modifying channel %lld fd %d events read %d write %d epoll %d", (long long) ch->id(), ch->fd(), ev.events & POLLIN, ev.events & POLLOUT, fd_);
     int r = epoll_ctl(fd_, EPOLL_CTL_MOD, ch->fd(), &ev);
     fatalif(r, "epoll_ctl mod failed %d %s", errno, strerror(errno));
 }
 
-void PollerEpoll::removeChannel(Channel* ch) {
-    trace("deleting channel %lld fd %d epoll %d", (long long)ch->id(), ch->fd(), fd_);
+void PollerEpoll::removeChannel(Channel *ch) {
+    trace("deleting channel %lld fd %d epoll %d", (long long) ch->id(), ch->fd(), fd_);
     liveChannels_.erase(ch);
-    for (int i = lastActive_; i >= 0; i --) {
+    for (int i = lastActive_; i >= 0; i--) {
         if (ch == activeEvs_[i].data.ptr) {
             activeEvs_[i].data.ptr = NULL;
             break;
@@ -84,20 +84,19 @@ void PollerEpoll::removeChannel(Channel* ch) {
 void PollerEpoll::loop_once(int waitMs) {
     int64_t ticks = util::timeMilli();
     lastActive_ = epoll_wait(fd_, activeEvs_, kMaxEvents, waitMs);
-    int64_t used = util::timeMilli()-ticks;
-    trace("epoll wait %d return %d errno %d used %lld millsecond",
-          waitMs, lastActive_, errno, (long long)used);
+    int64_t used = util::timeMilli() - ticks;
+    trace("epoll wait %d return %d errno %d used %lld millsecond", waitMs, lastActive_, errno, (long long) used);
     fatalif(lastActive_ == -1 && errno != EINTR, "epoll return error %d %s", errno, strerror(errno));
     while (--lastActive_ >= 0) {
         int i = lastActive_;
-        Channel* ch = (Channel*)activeEvs_[i].data.ptr;
+        Channel *ch = (Channel *) activeEvs_[i].data.ptr;
         int events = activeEvs_[i].events;
         if (ch) {
             if (events & (kReadEvent | POLLERR)) {
-                trace("channel %lld fd %d handle read", (long long)ch->id(), ch->fd());
+                trace("channel %lld fd %d handle read", (long long) ch->id(), ch->fd());
                 ch->handleRead();
             } else if (events & kWriteEvent) {
-                trace("channel %lld fd %d handle write", (long long)ch->id(), ch->fd());
+                trace("channel %lld fd %d handle write", (long long) ch->id(), ch->fd());
                 ch->handleWrite();
             } else {
                 fatal("unexpected poller events");
@@ -110,22 +109,24 @@ void PollerEpoll::loop_once(int waitMs) {
 
 struct PollerKqueue : public PollerBase {
     int fd_;
-    std::set<Channel*> liveChannels_;
-    //for epoll selected active events
+    std::set<Channel *> liveChannels_;
+    // for epoll selected active events
     struct kevent activeEvs_[kMaxEvents];
     PollerKqueue();
     ~PollerKqueue();
-    void addChannel(Channel* ch) override;
-    void removeChannel(Channel* ch) override;
-    void updateChannel(Channel* ch) override;
+    void addChannel(Channel *ch) override;
+    void removeChannel(Channel *ch) override;
+    void updateChannel(Channel *ch) override;
     void loop_once(int waitMs) override;
 };
 
-PollerBase* createPoller() { return new PollerKqueue(); }
+PollerBase *createPoller() {
+    return new PollerKqueue();
+}
 
-PollerKqueue::PollerKqueue(){
+PollerKqueue::PollerKqueue() {
     fd_ = kqueue();
-    fatalif(fd_ <0, "kqueue error %d %s", errno, strerror(errno));
+    fatalif(fd_ < 0, "kqueue error %d %s", errno, strerror(errno));
     info("poller kqueue %d created", fd_);
 }
 
@@ -138,52 +139,50 @@ PollerKqueue::~PollerKqueue() {
     info("poller %d destroyed", fd_);
 }
 
-void PollerKqueue::addChannel(Channel* ch) {
+void PollerKqueue::addChannel(Channel *ch) {
     struct timespec now;
     now.tv_nsec = 0;
     now.tv_sec = 0;
     struct kevent ev[2];
     int n = 0;
     if (ch->readEnabled()) {
-        EV_SET(&ev[n++], ch->fd(), EVFILT_READ, EV_ADD|EV_ENABLE, 0, 0, ch);
+        EV_SET(&ev[n++], ch->fd(), EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, ch);
     }
     if (ch->writeEnabled()) {
-        EV_SET(&ev[n++], ch->fd(), EVFILT_WRITE, EV_ADD|EV_ENABLE, 0, 0, ch);
+        EV_SET(&ev[n++], ch->fd(), EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, ch);
     }
-    trace("adding channel %lld fd %d events read %d write %d  epoll %d",
-          (long long)ch->id(), ch->fd(), ch->events() & POLLIN, ch->events() & POLLOUT, fd_);
+    trace("adding channel %lld fd %d events read %d write %d  epoll %d", (long long) ch->id(), ch->fd(), ch->events() & POLLIN, ch->events() & POLLOUT, fd_);
     int r = kevent(fd_, ev, n, NULL, 0, &now);
     fatalif(r, "kevent add failed %d %s", errno, strerror(errno));
     liveChannels_.insert(ch);
 }
 
-void PollerKqueue::updateChannel(Channel* ch) {
+void PollerKqueue::updateChannel(Channel *ch) {
     struct timespec now;
     now.tv_nsec = 0;
     now.tv_sec = 0;
     struct kevent ev[2];
     int n = 0;
     if (ch->readEnabled()) {
-        EV_SET(&ev[n++], ch->fd(), EVFILT_READ, EV_ADD|EV_ENABLE, 0, 0, ch);
+        EV_SET(&ev[n++], ch->fd(), EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, ch);
     } else {
         EV_SET(&ev[n++], ch->fd(), EVFILT_READ, EV_DELETE, 0, 0, ch);
     }
     if (ch->writeEnabled()) {
-        EV_SET(&ev[n++], ch->fd(), EVFILT_WRITE, EV_ADD|EV_ENABLE, 0, 0, ch);
+        EV_SET(&ev[n++], ch->fd(), EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, ch);
     } else {
         EV_SET(&ev[n++], ch->fd(), EVFILT_WRITE, EV_DELETE, 0, 0, ch);
     }
-    trace("modifying channel %lld fd %d events read %d write %d epoll %d",
-          (long long)ch->id(), ch->fd(), ch->events() & POLLIN, ch->events() & POLLOUT, fd_);
+    trace("modifying channel %lld fd %d events read %d write %d epoll %d", (long long) ch->id(), ch->fd(), ch->events() & POLLIN, ch->events() & POLLOUT, fd_);
     int r = kevent(fd_, ev, n, NULL, 0, &now);
     fatalif(r, "kevent mod failed %d %s", errno, strerror(errno));
 }
 
-void PollerKqueue::removeChannel(Channel* ch) {
-    trace("deleting channel %lld fd %d epoll %d", (long long)ch->id(), ch->fd(), fd_);
+void PollerKqueue::removeChannel(Channel *ch) {
+    trace("deleting channel %lld fd %d epoll %d", (long long) ch->id(), ch->fd(), fd_);
     liveChannels_.erase(ch);
     // remove channel if in ready stat
-    for (int i = lastActive_; i >= 0; i --) {
+    for (int i = lastActive_; i >= 0; i--) {
         if (ch == activeEvs_[i].udata) {
             activeEvs_[i].udata = NULL;
             break;
@@ -197,20 +196,19 @@ void PollerKqueue::loop_once(int waitMs) {
     timeout.tv_nsec = (waitMs % 1000) * 1000 * 1000;
     long ticks = util::timeMilli();
     lastActive_ = kevent(fd_, NULL, 0, activeEvs_, kMaxEvents, &timeout);
-    trace("kevent wait %d return %d errno %d used %lld millsecond",
-          waitMs, lastActive_, errno, util::timeMilli()-ticks);
+    trace("kevent wait %d return %d errno %d used %lld millsecond", waitMs, lastActive_, errno, util::timeMilli() - ticks);
     fatalif(lastActive_ == -1 && errno != EINTR, "kevent return error %d %s", errno, strerror(errno));
     while (--lastActive_ >= 0) {
         int i = lastActive_;
-        Channel* ch = (Channel*)activeEvs_[i].udata;
-        struct kevent& ke = activeEvs_[i];
+        Channel *ch = (Channel *) activeEvs_[i].udata;
+        struct kevent &ke = activeEvs_[i];
         if (ch) {
             // only handle write if read and write are enabled
             if (!(ke.flags & EV_EOF) && ch->writeEnabled()) {
-                trace("channel %lld fd %d handle write", (long long)ch->id(), ch->fd());
+                trace("channel %lld fd %d handle write", (long long) ch->id(), ch->fd());
                 ch->handleWrite();
             } else if ((ke.flags & EV_EOF) || ch->readEnabled()) {
-                trace("channel %lld fd %d handle read", (long long)ch->id(), ch->fd());
+                trace("channel %lld fd %d handle read", (long long) ch->id(), ch->fd());
                 ch->handleRead();
             } else {
                 fatal("unexpected epoll events %d", ch->events());
@@ -220,4 +218,4 @@ void PollerKqueue::loop_once(int waitMs) {
 }
 
 #endif
-}
+}  // namespace handy

--- a/handy/poller.h
+++ b/handy/poller.h
@@ -1,13 +1,11 @@
 #pragma once
-#include <poll.h>
 #include <assert.h>
-#include <map>
-#include <atomic>
+#include <poll.h>
+#include <string.h>
 #include <sys/time.h>
 #include <sys/types.h>
+#include <atomic>
 #include <map>
-#include <string.h>
-
 
 namespace handy {
 
@@ -15,17 +13,20 @@ const int kMaxEvents = 2000;
 const int kReadEvent = POLLIN;
 const int kWriteEvent = POLLOUT;
 
-struct PollerBase: private noncopyable {
+struct PollerBase : private noncopyable {
     int64_t id_;
     int lastActive_;
-    PollerBase(): lastActive_(-1) { static std::atomic<int64_t> id(0); id_ = ++id; }
-    virtual void addChannel(Channel* ch) = 0;
-    virtual void removeChannel(Channel* ch) = 0;
-    virtual void updateChannel(Channel* ch) = 0;
+    PollerBase() : lastActive_(-1) {
+        static std::atomic<int64_t> id(0);
+        id_ = ++id;
+    }
+    virtual void addChannel(Channel *ch) = 0;
+    virtual void removeChannel(Channel *ch) = 0;
+    virtual void updateChannel(Channel *ch) = 0;
     virtual void loop_once(int waitMs) = 0;
     virtual ~PollerBase(){};
 };
 
-PollerBase* createPoller();
+PollerBase *createPoller();
 
-}
+}  // namespace handy

--- a/handy/port_posix.cc
+++ b/handy/port_posix.cc
@@ -1,47 +1,49 @@
 #include "port_posix.h"
 #include <netdb.h>
-#include <string.h>
 #include <pthread.h>
-#include <unistd.h>
+#include <string.h>
 #include <sys/syscall.h>
+#include <unistd.h>
 
 namespace handy {
-namespace port{
+namespace port {
 #ifdef OS_LINUX
-    struct in_addr getHostByName(const std::string& host) {
-        struct in_addr addr;
-        char buf[1024];
-        struct hostent hent;
-        struct hostent* he = NULL;
-        int herrno = 0;
-        memset(&hent, 0, sizeof hent);
-        int r = gethostbyname_r(host.c_str(), &hent, buf, sizeof buf, &he, &herrno);
-        if (r == 0 && he && he->h_addrtype==AF_INET) {
-            addr = *reinterpret_cast<struct in_addr*>(he->h_addr);
-        } else {
-            addr.s_addr = INADDR_NONE;
-        }
-        return addr;
+struct in_addr getHostByName(const std::string &host) {
+    struct in_addr addr;
+    char buf[1024];
+    struct hostent hent;
+    struct hostent *he = NULL;
+    int herrno = 0;
+    memset(&hent, 0, sizeof hent);
+    int r = gethostbyname_r(host.c_str(), &hent, buf, sizeof buf, &he, &herrno);
+    if (r == 0 && he && he->h_addrtype == AF_INET) {
+        addr = *reinterpret_cast<struct in_addr *>(he->h_addr);
+    } else {
+        addr.s_addr = INADDR_NONE;
     }
-    uint64_t gettid() { return syscall(SYS_gettid); }
+    return addr;
+}
+uint64_t gettid() {
+    return syscall(SYS_gettid);
+}
 #elif defined(OS_MACOSX)
-    struct in_addr getHostByName(const std::string& host) {
-        struct in_addr addr;
-        struct hostent* he = gethostbyname(host.c_str());
-        if (he && he->h_addrtype == AF_INET) {
-            addr = *reinterpret_cast<struct in_addr*>(he->h_addr);
-        } else {
-            addr.s_addr = INADDR_NONE;
-        }
-        return addr;
+struct in_addr getHostByName(const std::string &host) {
+    struct in_addr addr;
+    struct hostent *he = gethostbyname(host.c_str());
+    if (he && he->h_addrtype == AF_INET) {
+        addr = *reinterpret_cast<struct in_addr *>(he->h_addr);
+    } else {
+        addr.s_addr = INADDR_NONE;
     }
-    uint64_t gettid() {
-        pthread_t tid = pthread_self();
-        uint64_t uid = 0;
-        memcpy(&uid, &tid, std::min(sizeof(tid), sizeof(uid)));
-        return uid;
-    }
+    return addr;
+}
+uint64_t gettid() {
+    pthread_t tid = pthread_self();
+    uint64_t uid = 0;
+    memcpy(&uid, &tid, std::min(sizeof(tid), sizeof(uid)));
+    return uid;
+}
 #endif
 
-}
-}
+}  // namespace port
+}  // namespace handy

--- a/handy/port_posix.h
+++ b/handy/port_posix.h
@@ -2,34 +2,40 @@
 #include <netinet/in.h>
 #include <string>
 namespace handy {
-    namespace port {
-        static const int kLittleEndian = LITTLE_ENDIAN;
-        inline uint16_t htobe(uint16_t v) {
-            if (!kLittleEndian) {
-                return v;
-            }
-            unsigned char* pv = (unsigned char*)&v;
-            return uint16_t(pv[0])<<8 | uint16_t(pv[1]);
-        }
-        inline uint32_t htobe(uint32_t v) {
-            if (!kLittleEndian) {
-                return v;
-            }
-            unsigned char* pv = (unsigned char*)&v;
-            return uint32_t(pv[0])<<24 | uint32_t(pv[1])<<16 | uint32_t(pv[2])<<8 | uint32_t(pv[3]);
-        }
-        inline uint64_t htobe(uint64_t v) {
-            if (!kLittleEndian) {
-                return v;
-            }
-            unsigned char* pv = (unsigned char*)&v;
-            return uint64_t(pv[0])<<56 | uint64_t(pv[1])<<48 | uint64_t(pv[2])<<40 | uint64_t(pv[3])<<32
-                   | uint64_t(pv[4])<<24 | uint64_t(pv[5])<<16 | uint64_t(pv[6])<<8 | uint64_t(pv[7]);
-        }
-        inline int16_t htobe(int16_t v) { return (int16_t)htobe((uint16_t)v); }
-        inline int32_t htobe(int32_t v) { return (int32_t)htobe((uint32_t)v); }
-        inline int64_t htobe(int64_t v) { return (int64_t)htobe((uint64_t)v); }
-        struct in_addr getHostByName(const std::string& host);
-        uint64_t gettid();
+namespace port {
+static const int kLittleEndian = LITTLE_ENDIAN;
+inline uint16_t htobe(uint16_t v) {
+    if (!kLittleEndian) {
+        return v;
     }
+    unsigned char *pv = (unsigned char *) &v;
+    return uint16_t(pv[0]) << 8 | uint16_t(pv[1]);
 }
+inline uint32_t htobe(uint32_t v) {
+    if (!kLittleEndian) {
+        return v;
+    }
+    unsigned char *pv = (unsigned char *) &v;
+    return uint32_t(pv[0]) << 24 | uint32_t(pv[1]) << 16 | uint32_t(pv[2]) << 8 | uint32_t(pv[3]);
+}
+inline uint64_t htobe(uint64_t v) {
+    if (!kLittleEndian) {
+        return v;
+    }
+    unsigned char *pv = (unsigned char *) &v;
+    return uint64_t(pv[0]) << 56 | uint64_t(pv[1]) << 48 | uint64_t(pv[2]) << 40 | uint64_t(pv[3]) << 32 | uint64_t(pv[4]) << 24 | uint64_t(pv[5]) << 16 |
+           uint64_t(pv[6]) << 8 | uint64_t(pv[7]);
+}
+inline int16_t htobe(int16_t v) {
+    return (int16_t) htobe((uint16_t) v);
+}
+inline int32_t htobe(int32_t v) {
+    return (int32_t) htobe((uint32_t) v);
+}
+inline int64_t htobe(int64_t v) {
+    return (int64_t) htobe((uint64_t) v);
+}
+struct in_addr getHostByName(const std::string &host);
+uint64_t gettid();
+}  // namespace port
+}  // namespace handy

--- a/handy/slice.h
+++ b/handy/slice.h
@@ -6,109 +6,118 @@
 namespace handy {
 
 class Slice {
-public:
+   public:
     Slice() : pb_("") { pe_ = pb_; }
-    Slice(const char* b, const char* e):pb_(b), pe_(e) {}
-    Slice(const char* d, size_t n) : pb_(d), pe_(d + n) { }
-    Slice(const std::string& s) : pb_(s.data()), pe_(s.data() + s.size()) { }
-    Slice(const char* s) : pb_(s), pe_(s + strlen(s)) { }
+    Slice(const char *b, const char *e) : pb_(b), pe_(e) {}
+    Slice(const char *d, size_t n) : pb_(d), pe_(d + n) {}
+    Slice(const std::string &s) : pb_(s.data()), pe_(s.data() + s.size()) {}
+    Slice(const char *s) : pb_(s), pe_(s + strlen(s)) {}
 
-    const char* data() const { return pb_; }
-    const char* begin() const { return pb_; }
-    const char* end() const { return pe_; }
+    const char *data() const { return pb_; }
+    const char *begin() const { return pb_; }
+    const char *end() const { return pe_; }
     char front() { return *pb_; }
     char back() { return pe_[-1]; }
     size_t size() const { return pe_ - pb_; }
     void resize(size_t sz) { pe_ = pb_ + sz; }
     inline bool empty() const { return pe_ == pb_; }
     void clear() { pe_ = pb_ = ""; }
-    
-    //return the eated data
+
+    // return the eated data
     Slice eatWord();
     Slice eatLine();
-    Slice eat(int sz) { Slice s(pb_, sz); pb_+=sz; return s; }
-    Slice sub(int boff, int eoff=0) const { Slice s(*this); s.pb_ += boff; s.pe_ += eoff; return s; }
-    Slice& trimSpace();
+    Slice eat(int sz) {
+        Slice s(pb_, sz);
+        pb_ += sz;
+        return s;
+    }
+    Slice sub(int boff, int eoff = 0) const {
+        Slice s(*this);
+        s.pb_ += boff;
+        s.pe_ += eoff;
+        return s;
+    }
+    Slice &trimSpace();
 
     inline char operator[](size_t n) const { return pb_[n]; }
 
     std::string toString() const { return std::string(pb_, pe_); }
     // Three-way comparison.  Returns value:
-    int compare(const Slice& b) const;
+    int compare(const Slice &b) const;
 
     // Return true if "x" is a prefix of "*this"
-    bool starts_with(const Slice& x) const {
-        return (size() >= x.size() && memcmp(pb_, x.pb_, x.size()) == 0); 
-    }
+    bool starts_with(const Slice &x) const { return (size() >= x.size() && memcmp(pb_, x.pb_, x.size()) == 0); }
 
-    bool end_with(const Slice& x) const {
-        return (size() >= x.size() && memcmp(pe_ - x.size(), x.pb_, x.size()) == 0); 
-    }
+    bool end_with(const Slice &x) const { return (size() >= x.size() && memcmp(pe_ - x.size(), x.pb_, x.size()) == 0); }
     operator std::string() const { return std::string(pb_, pe_); }
-    std::vector<Slice> split(char ch) const ;
-private:
-    const char* pb_;
-    const char* pe_;
+    std::vector<Slice> split(char ch) const;
+
+   private:
+    const char *pb_;
+    const char *pe_;
 };
 
 inline Slice Slice::eatWord() {
-    const char* b = pb_;
+    const char *b = pb_;
     while (b < pe_ && isspace(*b)) {
         b++;
     }
-    const char* e = b;
+    const char *e = b;
     while (e < pe_ && !isspace(*e)) {
-        e ++;
+        e++;
     }
     pb_ = e;
-    return Slice(b, e-b);
+    return Slice(b, e - b);
 }
 
-inline Slice Slice::eatLine() { 
-    const char* p = pb_; 
-    while (pb_<pe_ && *pb_ != '\n' && *pb_!='\r') {
-        pb_++; 
+inline Slice Slice::eatLine() {
+    const char *p = pb_;
+    while (pb_ < pe_ && *pb_ != '\n' && *pb_ != '\r') {
+        pb_++;
     }
-    return Slice(p, pb_-p); 
+    return Slice(p, pb_ - p);
 }
 
-inline Slice& Slice::trimSpace() {
-    while (pb_ < pe_ && isspace(*pb_)) pb_ ++;
-    while (pb_ < pe_ && isspace(pe_[-1])) pe_ --;
+inline Slice &Slice::trimSpace() {
+    while (pb_ < pe_ && isspace(*pb_))
+        pb_++;
+    while (pb_ < pe_ && isspace(pe_[-1]))
+        pe_--;
     return *this;
 }
 
-inline bool operator < (const Slice& x, const Slice& y) {
+inline bool operator<(const Slice &x, const Slice &y) {
     return x.compare(y) < 0;
 }
 
-inline bool operator==(const Slice& x, const Slice& y) {
-    return ((x.size() == y.size()) &&
-        (memcmp(x.data(), y.data(), x.size()) == 0));
+inline bool operator==(const Slice &x, const Slice &y) {
+    return ((x.size() == y.size()) && (memcmp(x.data(), y.data(), x.size()) == 0));
 }
 
-inline bool operator!=(const Slice& x, const Slice& y) {
+inline bool operator!=(const Slice &x, const Slice &y) {
     return !(x == y);
 }
 
-inline int Slice::compare(const Slice& b) const {
+inline int Slice::compare(const Slice &b) const {
     size_t sz = size(), bsz = b.size();
     const int min_len = (sz < bsz) ? sz : bsz;
     int r = memcmp(pb_, b.pb_, min_len);
     if (r == 0) {
-        if (sz < bsz) r = -1;
-        else if (sz > bsz) r = +1;
+        if (sz < bsz)
+            r = -1;
+        else if (sz > bsz)
+            r = +1;
     }
     return r;
 }
 
 inline std::vector<Slice> Slice::split(char ch) const {
     std::vector<Slice> r;
-    const char* pb = pb_;
-    for (const char* p = pb_; p < pe_; p++) {
+    const char *pb = pb_;
+    for (const char *p = pb_; p < pe_; p++) {
         if (*p == ch) {
             r.push_back(Slice(pb, p));
-            pb = p+1;
+            pb = p + 1;
         }
     }
     if (pe_ != pb_)
@@ -116,4 +125,4 @@ inline std::vector<Slice> Slice::split(char ch) const {
     return r;
 }
 
-}
+}  // namespace handy

--- a/handy/stat-svr.cc
+++ b/handy/stat-svr.cc
@@ -1,28 +1,28 @@
-#include "http.h"
-#include "logging.h"
 #include "stat-svr.h"
 #include "file.h"
+#include "http.h"
+#include "logging.h"
 
 using namespace std;
 
 namespace handy {
 
-static string query_link(const string& path) {
+static string query_link(const string &path) {
     return util::format("<a href=\"/?stat=%s\">%s</a>", path.c_str(), path.c_str());
 }
 
-static string page_link(const string& path) {
+static string page_link(const string &path) {
     return util::format("<a href=\"/%s\">%s</a>", path.c_str(), path.c_str());
 }
 
-StatServer::StatServer(EventBase* base): server_(base) {
-    server_.onDefault([this](const HttpConnPtr& con) {
-        HttpRequest& req = con.getRequest();
-        HttpResponse& resp = con.getResponse();
+StatServer::StatServer(EventBase *base) : server_(base) {
+    server_.onDefault([this](const HttpConnPtr &con) {
+        HttpRequest &req = con.getRequest();
+        HttpResponse &resp = con.getResponse();
         Buffer buf;
         string query = req.getArg("stat");
         if (query.empty()) {
-            query.assign(req.uri.data()+1, req.uri.size()-1);
+            query.assign(req.uri.data() + 1, req.uri.size() - 1);
         }
         if (query.size()) {
             auto p = allcbs_.find(query);
@@ -36,47 +36,44 @@ StatServer::StatServer(EventBase* base): server_(base) {
             buf.append("<a href=\"/\">refresh</a><br/>\n");
             buf.append("<table>\n");
             buf.append("<tr><td>Stat</td><td>Desc</td><td>Value</td></tr>\n");
-            for (auto& stat: statcbs_) {
+            for (auto &stat : statcbs_) {
                 HttpResponse r;
                 req.uri = stat.first;
                 stat.second.second(req, r);
-                buf.append("<tr><td>").append(page_link(stat.first))
-                    .append("</td><td>").append(stat.second.first)
-                    .append("</td><td>").append(r.body)
+                buf.append("<tr><td>")
+                    .append(page_link(stat.first))
+                    .append("</td><td>")
+                    .append(stat.second.first)
+                    .append("</td><td>")
+                    .append(r.body)
                     .append("</td></tr>\n");
             }
-            buf.append("</table>\n<br/>\n<table>\n")
-                .append("<tr><td>Page</td><td>Desc</td>\n");
-            for (auto& stat: pagecbs_) {
-                buf.append("<tr><td>").append(page_link(stat.first))
-                    .append("</td><td>").append(stat.second.first)
-                    .append("</td></tr>\n");
+            buf.append("</table>\n<br/>\n<table>\n").append("<tr><td>Page</td><td>Desc</td>\n");
+            for (auto &stat : pagecbs_) {
+                buf.append("<tr><td>").append(page_link(stat.first)).append("</td><td>").append(stat.second.first).append("</td></tr>\n");
             }
-            buf.append("</table>\n<br/>\n<table>\n")
-                .append("<tr><td>Cmd</td><td>Desc</td>\n");
-            for (auto& stat: cmdcbs_) {
-                buf.append("<tr><td>").append(query_link(stat.first))
-                    .append("</td><td>").append(stat.second.first)
-                    .append("</td></tr>\n");
+            buf.append("</table>\n<br/>\n<table>\n").append("<tr><td>Cmd</td><td>Desc</td>\n");
+            for (auto &stat : cmdcbs_) {
+                buf.append("<tr><td>").append(query_link(stat.first)).append("</td><td>").append(stat.second.first).append("</td></tr>\n");
             }
             buf.append("</table>\n");
             if (resp.body.size()) {
                 buf.append(util::format("<br/>SubQuery %s:<br/> %s", query.c_str(), resp.body.c_str()));
             }
             resp.body = Slice(buf.data(), buf.size());
-       }
-        info("response is: %d \n%.*s", resp.status, (int)resp.body.size(), resp.body.data());
+        }
+        info("response is: %d \n%.*s", resp.status, (int) resp.body.size(), resp.body.data());
         con.sendResponse();
     });
 }
 
-void StatServer::onRequest(StatType type, const string& key, const string& desc, const StatCallBack& cb){
+void StatServer::onRequest(StatType type, const string &key, const string &desc, const StatCallBack &cb) {
     if (type == STATE) {
-        statcbs_[key] = { desc, cb };
+        statcbs_[key] = {desc, cb};
     } else if (type == PAGE) {
-        pagecbs_[key] = { desc, cb };
+        pagecbs_[key] = {desc, cb};
     } else if (type == CMD) {
-        cmdcbs_[key] = { desc, cb};
+        cmdcbs_[key] = {desc, cb};
     } else {
         error("unknow state type: %d", type);
         return;
@@ -84,14 +81,12 @@ void StatServer::onRequest(StatType type, const string& key, const string& desc,
     allcbs_[key] = cb;
 }
 
-void StatServer::onRequest(StatType type, const string& key, const string& desc, const InfoCallBack& cb) {
-    onRequest(type, key, desc, [cb](const HttpRequest&, HttpResponse& r) {
-        r.body = cb();
-    });
+void StatServer::onRequest(StatType type, const string &key, const string &desc, const InfoCallBack &cb) {
+    onRequest(type, key, desc, [cb](const HttpRequest &, HttpResponse &r) { r.body = cb(); });
 }
 
-void StatServer::onPageFile(const string& page, const string& desc, const string& file) {
-    return onRequest(PAGE, page, desc, [file] ( const HttpRequest& req, HttpResponse& resp) {
+void StatServer::onPageFile(const string &page, const string &desc, const string &file) {
+    return onRequest(PAGE, page, desc, [file](const HttpRequest &req, HttpResponse &resp) {
         Status st = file::getContent(file, resp.body);
         if (!st.ok()) {
             error("get file %s failed %s", file.c_str(), st.toString().c_str());
@@ -102,4 +97,4 @@ void StatServer::onPageFile(const string& page, const string& desc, const string
     });
 }
 
-}
+}  // namespace handy

--- a/handy/stat-svr.h
+++ b/handy/stat-svr.h
@@ -1,38 +1,47 @@
 #pragma once
 
-#include "slice.h"
+#include <functional>
+#include <map>
 #include "event_base.h"
 #include "http.h"
-#include <map>
-#include <functional>
+#include "slice.h"
 
 namespace handy {
 
-typedef std::function<void(const HttpRequest&, HttpResponse&)> StatCallBack;
+typedef std::function<void(const HttpRequest &, HttpResponse &)> StatCallBack;
 typedef std::function<std::string()> InfoCallBack;
 typedef std::function<int64_t()> IntCallBack;
 
-struct StatServer: private noncopyable {
-    enum StatType { STATE, PAGE, CMD, };
-    StatServer(EventBase* base);
-    int bind(const std::string& host, short port) { return server_.bind(host, port); }
+struct StatServer : private noncopyable {
+    enum StatType {
+        STATE,
+        PAGE,
+        CMD,
+    };
+    StatServer(EventBase *base);
+    int bind(const std::string &host, short port) { return server_.bind(host, port); }
     typedef std::string string;
-    void onRequest(StatType type, const string& key, const string& desc, const StatCallBack& cb);
-    void onRequest(StatType type, const string& key, const string& desc, const InfoCallBack& cb);
+    void onRequest(StatType type, const string &key, const string &desc, const StatCallBack &cb);
+    void onRequest(StatType type, const string &key, const string &desc, const InfoCallBack &cb);
     //用于展示一个简单的state
-    void onState(const string& state, const string& desc, const InfoCallBack& cb) { onRequest(STATE, state, desc, cb); }
-    void onState(const string& state, const string& desc, const IntCallBack& cb) { onRequest(STATE, state, desc, [cb] { return util::format("%ld", cb()); }); }
+    void onState(const string &state, const string &desc, const InfoCallBack &cb) { onRequest(STATE, state, desc, cb); }
+    void onState(const string &state, const string &desc, const IntCallBack &cb) {
+        onRequest(STATE, state, desc, [cb] { return util::format("%ld", cb()); });
+    }
     //用于展示一个页面
-    void onPage(const string& page, const string& desc, const InfoCallBack& cb) { onRequest(PAGE, page, desc, cb); }
-    void onPageFile(const string& page, const string& desc, const string& file);
+    void onPage(const string &page, const string &desc, const InfoCallBack &cb) { onRequest(PAGE, page, desc, cb); }
+    void onPageFile(const string &page, const string &desc, const string &file);
     //用于发送一个命令
-    void onCmd(const string& cmd, const string& desc, const InfoCallBack& cb) { onRequest(CMD, cmd, desc, cb); }
-    void onCmd(const string& cmd, const string& desc, const IntCallBack& cb) { onRequest(CMD, cmd, desc, [cb] { return util::format("%ld", cb()); }); }
-private:
+    void onCmd(const string &cmd, const string &desc, const InfoCallBack &cb) { onRequest(CMD, cmd, desc, cb); }
+    void onCmd(const string &cmd, const string &desc, const IntCallBack &cb) {
+        onRequest(CMD, cmd, desc, [cb] { return util::format("%ld", cb()); });
+    }
+
+   private:
     HttpServer server_;
     typedef std::pair<std::string, StatCallBack> DescState;
     std::map<std::string, DescState> statcbs_, pagecbs_, cmdcbs_;
     std::map<std::string, StatCallBack> allcbs_;
 };
 
-}
+}  // namespace handy

--- a/handy/status.h
+++ b/handy/status.h
@@ -1,78 +1,88 @@
 #pragma once
 #include <errno.h>
-#include <string.h>
 #include <stdarg.h>
+#include <string.h>
 #include "util.h"
 
 namespace handy {
 
-inline const char* errstr(){ return strerror(errno); }
+inline const char *errstr() {
+    return strerror(errno);
+}
 
 struct Status {
     // Create a success status.
-    Status() : state_(NULL) { }
-    Status(int code, const char* msg);
-    Status(int code, const std::string& msg): Status(code, msg.c_str()) {}
+    Status() : state_(NULL) {}
+    Status(int code, const char *msg);
+    Status(int code, const std::string &msg) : Status(code, msg.c_str()) {}
     ~Status() { delete[] state_; }
 
     // Copy the specified status.
-    Status(const Status& s) { state_ = copyState(s.state_); }
-    void operator=(const Status& s) { delete[] state_; state_ = copyState(s.state_); }
-    Status(Status&& s) { state_ = s.state_; s.state_ = NULL; }
-    void operator = (Status&& s) { delete[] state_; state_ = s.state_; s.state_ = NULL; }
+    Status(const Status &s) { state_ = copyState(s.state_); }
+    void operator=(const Status &s) {
+        delete[] state_;
+        state_ = copyState(s.state_);
+    }
+    Status(Status &&s) {
+        state_ = s.state_;
+        s.state_ = NULL;
+    }
+    void operator=(Status &&s) {
+        delete[] state_;
+        state_ = s.state_;
+        s.state_ = NULL;
+    }
 
     static Status fromSystem() { return Status(errno, strerror(errno)); }
     static Status fromSystem(int err) { return Status(err, strerror(err)); }
-    static Status fromFormat(int code, const char* fmt, ...);
-    static Status ioError(const std::string& op, const std::string& name) {
-        return Status::fromFormat(errno, "%s %s %s", op.c_str(), name.c_str(), errstr());
-    }
+    static Status fromFormat(int code, const char *fmt, ...);
+    static Status ioError(const std::string &op, const std::string &name) { return Status::fromFormat(errno, "%s %s %s", op.c_str(), name.c_str(), errstr()); }
 
-
-    int code() { return state_ ? *(int32_t*)(state_+4) : 0; }
-    const char* msg() { return state_ ? state_ + 8 : ""; }
+    int code() { return state_ ? *(int32_t *) (state_ + 4) : 0; }
+    const char *msg() { return state_ ? state_ + 8 : ""; }
     bool ok() { return code() == 0; }
     std::string toString() { return util::format("%d %s", code(), msg()); }
-private:
+
+   private:
     //    state_[0..3] == length of message
     //    state_[4..7]    == code
     //    state_[8..]  == message
-    const char* state_;
-    const char* copyState(const char* state);
+    const char *state_;
+    const char *copyState(const char *state);
 };
 
-inline const char* Status::copyState(const char* state) {
+inline const char *Status::copyState(const char *state) {
     if (state == NULL) {
         return state;
     }
-    uint32_t size = *(uint32_t*)state;
-    char* res = new char[size];
+    uint32_t size = *(uint32_t *) state;
+    char *res = new char[size];
     memcpy(res, state, size);
     return res;
 }
 
-inline Status::Status(int code, const char* msg) {
+inline Status::Status(int code, const char *msg) {
     uint32_t sz = strlen(msg) + 8;
-    char* p = new char[sz];
+    char *p = new char[sz];
     state_ = p;
-    *(uint32_t*)p= sz;
-    *(int32_t*)(p+4) = code;
-    memcpy(p+8, msg, sz-8);
+    *(uint32_t *) p = sz;
+    *(int32_t *) (p + 4) = code;
+    memcpy(p + 8, msg, sz - 8);
 }
 
-inline Status Status::fromFormat(int code, const char* fmt, ...) {
+inline Status Status::fromFormat(int code, const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
-    uint32_t size  = 8 + vsnprintf(NULL, 0, fmt, ap) + 1;
+    uint32_t size = 8 + vsnprintf(NULL, 0, fmt, ap) + 1;
     va_end(ap);
     Status r;
     r.state_ = new char[size];
-    *(uint32_t*)r.state_ = size;
-    *(int32_t*)(r.state_+4) = code;
+    *(uint32_t *) r.state_ = size;
+    *(int32_t *) (r.state_ + 4) = code;
     va_start(ap, fmt);
-    vsnprintf((char*)r.state_+8, size - 8, fmt, ap);
+    vsnprintf((char *) r.state_ + 8, size - 8, fmt, ap);
     va_end(ap);
     return r;
 }
 
-}
+}  // namespace handy

--- a/handy/threads.cc
+++ b/handy/threads.cc
@@ -7,9 +7,7 @@ namespace handy {
 
 template class SafeQueue<Task>;
 
-ThreadPool::ThreadPool(int threads, int maxWaiting, bool start): 
-tasks_(maxWaiting), threads_(threads)
-{
+ThreadPool::ThreadPool(int threads, int maxWaiting, bool start) : tasks_(maxWaiting), threads_(threads) {
     if (start) {
         this->start();
     }
@@ -18,35 +16,32 @@ tasks_(maxWaiting), threads_(threads)
 ThreadPool::~ThreadPool() {
     assert(tasks_.exited());
     if (tasks_.size()) {
-        fprintf(stderr, "%lu tasks not processed when thread pool exited\n",
-            tasks_.size());
+        fprintf(stderr, "%lu tasks not processed when thread pool exited\n", tasks_.size());
     }
 }
 
 void ThreadPool::start() {
-    for (auto& th: threads_) {
-        thread t(
-            [this] {
-                while (!tasks_.exited()) {
-                    Task task;
-                    if (tasks_.pop_wait(&task)) {
-                        task();
-                    }
+    for (auto &th : threads_) {
+        thread t([this] {
+            while (!tasks_.exited()) {
+                Task task;
+                if (tasks_.pop_wait(&task)) {
+                    task();
                 }
             }
-        );
+        });
         th.swap(t);
     }
 }
 
 void ThreadPool::join() {
-    for (auto& t: threads_) {
+    for (auto &t : threads_) {
         t.join();
     }
 }
 
-bool ThreadPool::addTask(Task&& task) {
+bool ThreadPool::addTask(Task &&task) {
     return tasks_.push(move(task));
 }
 
-}
+}  // namespace handy

--- a/handy/threads.h
+++ b/handy/threads.h
@@ -1,71 +1,80 @@
 #pragma once
-#include <thread>
 #include <atomic>
-#include <list>
-#include <vector>
+#include <condition_variable>
 #include <functional>
 #include <limits>
-#include <condition_variable>
+#include <list>
 #include <mutex>
+#include <thread>
+#include <vector>
 #include "util.h"
 
 namespace handy {
 
-template<typename T> struct SafeQueue: private std::mutex, private noncopyable {
+template <typename T>
+struct SafeQueue : private std::mutex, private noncopyable {
     static const int wait_infinite = std::numeric_limits<int>::max();
-    //0 不限制队列中的任务数
-    SafeQueue(size_t capacity=0): capacity_(capacity), exit_(false) {}
+    // 0 不限制队列中的任务数
+    SafeQueue(size_t capacity = 0) : capacity_(capacity), exit_(false) {}
     //队列满则返回false
-    bool push(T&& v);
+    bool push(T &&v);
     //超时则返回T()
-    T pop_wait(int waitMs=wait_infinite);
+    T pop_wait(int waitMs = wait_infinite);
     //超时返回false
-    bool pop_wait(T* v, int waitMs=wait_infinite);
+    bool pop_wait(T *v, int waitMs = wait_infinite);
 
     size_t size();
     void exit();
     bool exited() { return exit_; }
-private: 
+
+   private:
     std::list<T> items_;
     std::condition_variable ready_;
     size_t capacity_;
     std::atomic<bool> exit_;
-    void wait_ready(std::unique_lock<std::mutex>& lk, int waitMs);
+    void wait_ready(std::unique_lock<std::mutex> &lk, int waitMs);
 };
 
 typedef std::function<void()> Task;
 extern template class SafeQueue<Task>;
 
-struct ThreadPool: private noncopyable {
+struct ThreadPool : private noncopyable {
     //创建线程池
-    ThreadPool(int threads, int taskCapacity=0, bool start=true);
+    ThreadPool(int threads, int taskCapacity = 0, bool start = true);
     ~ThreadPool();
     void start();
-    ThreadPool& exit() { tasks_.exit(); return *this; }
+    ThreadPool &exit() {
+        tasks_.exit();
+        return *this;
+    }
     void join();
 
     //队列满返回false
-    bool addTask(Task&& task);
-    bool addTask(Task& task) { return addTask(Task(task)); }
+    bool addTask(Task &&task);
+    bool addTask(Task &task) { return addTask(Task(task)); }
     size_t taskSize() { return tasks_.size(); }
-private:
+
+   private:
     SafeQueue<Task> tasks_;
     std::vector<std::thread> threads_;
 };
 
 //以下为实现代码，不必关心
-template<typename T> size_t SafeQueue<T>::size() {
+template <typename T>
+size_t SafeQueue<T>::size() {
     std::lock_guard<std::mutex> lk(*this);
     return items_.size();
 }
 
-template<typename T> void SafeQueue<T>::exit() {
+template <typename T>
+void SafeQueue<T>::exit() {
     exit_ = true;
     std::lock_guard<std::mutex> lk(*this);
     ready_.notify_all();
 }
 
-template<typename T> bool SafeQueue<T>::push(T&& v) {
+template <typename T>
+bool SafeQueue<T>::push(T &&v) {
     std::lock_guard<std::mutex> lk(*this);
     if (exit_ || (capacity_ && items_.size() >= capacity_)) {
         return false;
@@ -74,26 +83,22 @@ template<typename T> bool SafeQueue<T>::push(T&& v) {
     ready_.notify_one();
     return true;
 }
-template<typename T> void SafeQueue<T>::wait_ready(
-    std::unique_lock<std::mutex>& lk, int waitMs)
-{
+template <typename T>
+void SafeQueue<T>::wait_ready(std::unique_lock<std::mutex> &lk, int waitMs) {
     if (exit_ || !items_.empty()) {
         return;
     }
     if (waitMs == wait_infinite) {
-        ready_.wait(lk, [this]{ return exit_ || !items_.empty(); });
-    } else if (waitMs > 0){
-        auto tp = std::chrono::steady_clock::now()
-            + std::chrono::milliseconds(waitMs);
-        while (ready_.wait_until(lk, tp) != std::cv_status::timeout 
-            && items_.empty() && !exit_) {
+        ready_.wait(lk, [this] { return exit_ || !items_.empty(); });
+    } else if (waitMs > 0) {
+        auto tp = std::chrono::steady_clock::now() + std::chrono::milliseconds(waitMs);
+        while (ready_.wait_until(lk, tp) != std::cv_status::timeout && items_.empty() && !exit_) {
         }
     }
 }
 
-
-
-template<typename T> bool SafeQueue<T>::pop_wait(T* v, int waitMs) {
+template <typename T>
+bool SafeQueue<T>::pop_wait(T *v, int waitMs) {
     std::unique_lock<std::mutex> lk(*this);
     wait_ready(lk, waitMs);
     if (items_.empty()) {
@@ -104,7 +109,8 @@ template<typename T> bool SafeQueue<T>::pop_wait(T* v, int waitMs) {
     return true;
 }
 
-template<typename T> T SafeQueue<T>::pop_wait(int waitMs) {
+template <typename T>
+T SafeQueue<T>::pop_wait(int waitMs) {
     std::unique_lock<std::mutex> lk(*this);
     wait_ready(lk, waitMs);
     if (items_.empty()) {
@@ -115,4 +121,4 @@ template<typename T> T SafeQueue<T>::pop_wait(int waitMs) {
     return r;
 }
 
-}
+}  // namespace handy

--- a/handy/udp.h
+++ b/handy/udp.h
@@ -4,81 +4,94 @@
 
 namespace handy {
 
-    struct UdpServer;
-    struct UdpConn;
-    typedef std::shared_ptr<UdpConn> UdpConnPtr;
-    typedef std::shared_ptr<UdpServer> UdpServerPtr;
-    typedef std::function<void(const UdpConnPtr&, Buffer)> UdpCallBack;
-    typedef std::function<void(const UdpServerPtr&, Buffer, Ip4Addr)> UdpSvrCallBack;
-    const int kUdpPacketSize = 4096;
-    //Udp服务器
-    struct UdpServer : public std::enable_shared_from_this<UdpServer>, private noncopyable {
-        UdpServer(EventBases* bases);
-        //return 0 on sucess, errno on error
-        int bind(const std::string& host, short port, bool reusePort=false);
-        static UdpServerPtr startServer(EventBases* bases, const std::string& host, short port, bool reusePort=false);
-        ~UdpServer() { delete channel_; }
-        Ip4Addr getAddr() { return addr_; }
-        EventBase* getBase() { return base_; }
-        void sendTo(Buffer msg, Ip4Addr addr) { sendTo(msg.data(), msg.size(), addr); msg.clear(); }
-        void sendTo(const char* buf, size_t len, Ip4Addr addr);
-        void sendTo(const std::string& s, Ip4Addr addr) { sendTo(s.data(), s.size(), addr); }
-        void sendTo(const char* s, Ip4Addr addr) { sendTo(s, strlen(s), addr); }
+struct UdpServer;
+struct UdpConn;
+typedef std::shared_ptr<UdpConn> UdpConnPtr;
+typedef std::shared_ptr<UdpServer> UdpServerPtr;
+typedef std::function<void(const UdpConnPtr &, Buffer)> UdpCallBack;
+typedef std::function<void(const UdpServerPtr &, Buffer, Ip4Addr)> UdpSvrCallBack;
+const int kUdpPacketSize = 4096;
+// Udp服务器
+struct UdpServer : public std::enable_shared_from_this<UdpServer>, private noncopyable {
+    UdpServer(EventBases *bases);
+    // return 0 on sucess, errno on error
+    int bind(const std::string &host, short port, bool reusePort = false);
+    static UdpServerPtr startServer(EventBases *bases, const std::string &host, short port, bool reusePort = false);
+    ~UdpServer() { delete channel_; }
+    Ip4Addr getAddr() { return addr_; }
+    EventBase *getBase() { return base_; }
+    void sendTo(Buffer msg, Ip4Addr addr) {
+        sendTo(msg.data(), msg.size(), addr);
+        msg.clear();
+    }
+    void sendTo(const char *buf, size_t len, Ip4Addr addr);
+    void sendTo(const std::string &s, Ip4Addr addr) { sendTo(s.data(), s.size(), addr); }
+    void sendTo(const char *s, Ip4Addr addr) { sendTo(s, strlen(s), addr); }
 
-        //消息的处理
-        void onMsg(const UdpSvrCallBack& cb) { msgcb_ = cb; }
-    private:
-        EventBase* base_;
-        EventBases* bases_;
-        Ip4Addr addr_;
-        Channel*channel_;
-        UdpSvrCallBack msgcb_;
-    };
+    //消息的处理
+    void onMsg(const UdpSvrCallBack &cb) { msgcb_ = cb; }
 
-    //Udp连接，使用引用计数
-    struct UdpConn: public std::enable_shared_from_this<UdpConn>, private noncopyable {
-        //Udp构造函数，实际可用的连接应当通过createConnection创建
-        UdpConn(){};
-        virtual ~UdpConn() {close();};
-        static UdpConnPtr createConnection(EventBase* base, const std::string& host, short port);
-        //automatically managed context. allocated when first used, deleted when destruct
-        template<class T> T& context() { return ctx_.context<T>(); }
+   private:
+    EventBase *base_;
+    EventBases *bases_;
+    Ip4Addr addr_;
+    Channel *channel_;
+    UdpSvrCallBack msgcb_;
+};
 
-        EventBase* getBase() { return base_; }
-        Channel* getChannel() { return channel_; }
+// Udp连接，使用引用计数
+struct UdpConn : public std::enable_shared_from_this<UdpConn>, private noncopyable {
+    // Udp构造函数，实际可用的连接应当通过createConnection创建
+    UdpConn(){};
+    virtual ~UdpConn() { close(); };
+    static UdpConnPtr createConnection(EventBase *base, const std::string &host, short port);
+    // automatically managed context. allocated when first used, deleted when destruct
+    template <class T>
+    T &context() {
+        return ctx_.context<T>();
+    }
 
-        //发送数据
-        void send(Buffer msg) { send(msg.data(), msg.size()); msg.clear(); }
-        void send(const char* buf, size_t len);
-        void send(const std::string& s) { send(s.data(), s.size()); }
-        void send(const char* s) { send(s, strlen(s)); }
-        void onMsg(const UdpCallBack& cb) { cb_ = cb; }
-        void close();
-        //远程地址的字符串
-        std::string str() { return peer_.toString(); }
-    public:
-        void handleRead(const UdpConnPtr&);
-        EventBase* base_;
-        Channel* channel_;
-        Ip4Addr local_, peer_;
-        AutoContext ctx_;
-        std::string destHost_;
-        int destPort_;
-        UdpCallBack cb_;
-    };
+    EventBase *getBase() { return base_; }
+    Channel *getChannel() { return channel_; }
 
-    typedef std::function<std::string (const UdpServerPtr&, const std::string&, Ip4Addr)> RetMsgUdpCallBack;
-    //半同步半异步服务器
-    struct HSHAU;
-    typedef std::shared_ptr<HSHAU> HSHAUPtr;
-    struct HSHAU {
-        static HSHAUPtr startServer(EventBase* base, const std::string& host, short port, int threads);
-        HSHAU(int threads): threadPool_(threads) {}
-        void exit() {threadPool_.exit(); threadPool_.join(); }
-        void onMsg(const RetMsgUdpCallBack& cb);
-        UdpServerPtr server_;
-        ThreadPool threadPool_;
-    };
+    //发送数据
+    void send(Buffer msg) {
+        send(msg.data(), msg.size());
+        msg.clear();
+    }
+    void send(const char *buf, size_t len);
+    void send(const std::string &s) { send(s.data(), s.size()); }
+    void send(const char *s) { send(s, strlen(s)); }
+    void onMsg(const UdpCallBack &cb) { cb_ = cb; }
+    void close();
+    //远程地址的字符串
+    std::string str() { return peer_.toString(); }
 
+   public:
+    void handleRead(const UdpConnPtr &);
+    EventBase *base_;
+    Channel *channel_;
+    Ip4Addr local_, peer_;
+    AutoContext ctx_;
+    std::string destHost_;
+    int destPort_;
+    UdpCallBack cb_;
+};
 
-}
+typedef std::function<std::string(const UdpServerPtr &, const std::string &, Ip4Addr)> RetMsgUdpCallBack;
+//半同步半异步服务器
+struct HSHAU;
+typedef std::shared_ptr<HSHAU> HSHAUPtr;
+struct HSHAU {
+    static HSHAUPtr startServer(EventBase *base, const std::string &host, short port, int threads);
+    HSHAU(int threads) : threadPool_(threads) {}
+    void exit() {
+        threadPool_.exit();
+        threadPool_.join();
+    }
+    void onMsg(const RetMsgUdpCallBack &cb);
+    UdpServerPtr server_;
+    ThreadPool threadPool_;
+};
+
+}  // namespace handy

--- a/handy/util.cc
+++ b/handy/util.cc
@@ -1,18 +1,18 @@
 #include "util.h"
+#include <fcntl.h>
 #include <stdarg.h>
-#include <memory>
 #include <algorithm>
 #include <chrono>
-#include <fcntl.h>
+#include <memory>
 
 using namespace std;
 
 namespace handy {
 
-string util::format(const char* fmt, ...) {
+string util::format(const char *fmt, ...) {
     char buffer[500];
     unique_ptr<char[]> release1;
-    char* base;
+    char *base;
     for (int iter = 0; iter < 2; iter++) {
         int bufsize;
         if (iter == 0) {
@@ -23,8 +23,8 @@ string util::format(const char* fmt, ...) {
             base = new char[bufsize];
             release1.reset(base);
         }
-        char* p = base;
-        char* limit = base + bufsize;
+        char *p = base;
+        char *limit = base + bufsize;
         if (p < limit) {
             va_list ap;
             va_start(ap, fmt);
@@ -34,7 +34,7 @@ string util::format(const char* fmt, ...) {
         // Truncate to available space if necessary
         if (p >= limit) {
             if (iter == 0) {
-                continue;       // Try again with larger buffer
+                continue;  // Try again with larger buffer
             } else {
                 p = limit - 1;
                 *p = '\0';
@@ -57,8 +57,7 @@ int64_t util::steadyMicro() {
 std::string util::readableTime(time_t t) {
     struct tm tm1;
     localtime_r(&t, &tm1);
-    return format("%04d-%02d-%02d %02d:%02d:%02d",
-        tm1.tm_year+1900, tm1.tm_mon+1, tm1.tm_mday, tm1.tm_hour, tm1.tm_min, tm1.tm_sec);
+    return format("%04d-%02d-%02d %02d:%02d:%02d", tm1.tm_year + 1900, tm1.tm_mon + 1, tm1.tm_mday, tm1.tm_hour, tm1.tm_min, tm1.tm_sec);
 }
 
 int util::addFdFlag(int fd, int flag) {
@@ -66,4 +65,4 @@ int util::addFdFlag(int fd, int flag) {
     return fcntl(fd, F_SETFD, ret | flag);
 }
 
-}
+}  // namespace handy

--- a/handy/util.h
+++ b/handy/util.h
@@ -1,44 +1,45 @@
 #pragma once
-#include <string>
+#include <stdlib.h>
+#include <string.h>
 #include <functional>
+#include <string>
 #include <utility>
 #include <vector>
-#include <string.h>
-#include <stdlib.h>
 
 namespace handy {
 
 struct noncopyable {
-protected:
+   protected:
     noncopyable() = default;
     virtual ~noncopyable() = default;
 
-    noncopyable(const noncopyable&) = delete;
-    noncopyable& operator=(const noncopyable&) = delete;
+    noncopyable(const noncopyable &) = delete;
+    noncopyable &operator=(const noncopyable &) = delete;
 };
 
 struct util {
-    static std::string format(const char* fmt, ...);
+    static std::string format(const char *fmt, ...);
     static int64_t timeMicro();
-    static int64_t timeMilli() { return timeMicro()/1000; }
+    static int64_t timeMilli() { return timeMicro() / 1000; }
     static int64_t steadyMicro();
-    static int64_t steadyMilli() { return steadyMicro()/1000; }
+    static int64_t steadyMilli() { return steadyMicro() / 1000; }
     static std::string readableTime(time_t t);
-    static int64_t atoi(const char* b, const char* e) { return strtol(b, (char**)&e, 10); }
-    static int64_t atoi2(const char* b, const char* e) {
-        char** ne = (char**)&e;
+    static int64_t atoi(const char *b, const char *e) { return strtol(b, (char **) &e, 10); }
+    static int64_t atoi2(const char *b, const char *e) {
+        char **ne = (char **) &e;
         int64_t v = strtol(b, ne, 10);
-        return ne == (char**)&e ? v : -1;
+        return ne == (char **) &e ? v : -1;
     }
-    static int64_t atoi(const char* b) { return atoi(b, b+strlen(b)); }
+    static int64_t atoi(const char *b) { return atoi(b, b + strlen(b)); }
     static int addFdFlag(int fd, int flag);
 };
 
-struct ExitCaller: private noncopyable {
+struct ExitCaller : private noncopyable {
     ~ExitCaller() { functor_(); }
-    ExitCaller(std::function<void()>&& functor): functor_(std::move(functor)) {}
-private:
+    ExitCaller(std::function<void()> &&functor) : functor_(std::move(functor)) {}
+
+   private:
     std::function<void()> functor_;
 };
 
-}
+}  // namespace handy

--- a/protobuf/proto_msg.cc
+++ b/protobuf/proto_msg.cc
@@ -1,12 +1,12 @@
 #include "proto_msg.h"
-#include <string>
 #include <google/protobuf/descriptor.h>
+#include <string>
 
 using namespace std;
 using namespace google::protobuf;
 
 namespace handy {
-void ProtoMsgDispatcher::handle(TcpConnPtr con, Message* msg) {
+void ProtoMsgDispatcher::handle(TcpConnPtr con, Message *msg) {
     auto p = protocbs_.find(msg->GetDescriptor());
     if (p != protocbs_.end()) {
         p->second(con, msg);
@@ -19,24 +19,23 @@ void ProtoMsgDispatcher::handle(TcpConnPtr con, Message* msg) {
 // 4 byte name len
 // name string not null ended
 // protobuf data
-Message* ProtoMsgCodec::decode(Buffer& s){
+Message *ProtoMsgCodec::decode(Buffer &s) {
     if (s.size() < 8) {
         error("buffer is too small size: %lu", s.size());
         return NULL;
     }
-    char* p = s.data();
-    uint32_t msglen = *(uint32_t*)p;
-    uint32_t namelen = *(uint32_t*)(p+4);
+    char *p = s.data();
+    uint32_t msglen = *(uint32_t *) p;
+    uint32_t namelen = *(uint32_t *) (p + 4);
     if (s.size() < msglen || s.size() < 4 + namelen) {
-        error("buf format error size %lu msglen %d namelen %d", 
-            s.size(), msglen, namelen);
+        error("buf format error size %lu msglen %d namelen %d", s.size(), msglen, namelen);
         return NULL;
     }
     string typeName(p + 8, namelen);
-    Message* msg = NULL;
-    const Descriptor* des = DescriptorPool::generated_pool()->FindMessageTypeByName(typeName);
+    Message *msg = NULL;
+    const Descriptor *des = DescriptorPool::generated_pool()->FindMessageTypeByName(typeName);
     if (des) {
-        const Message* proto = MessageFactory::generated_factory()->GetPrototype(des);
+        const Message *proto = MessageFactory::generated_factory()->GetPrototype(des);
         if (proto) {
             msg = proto->New();
         }
@@ -55,14 +54,14 @@ Message* ProtoMsgCodec::decode(Buffer& s){
     return msg;
 }
 
-void ProtoMsgCodec::encode(Message* msg, Buffer& buf) {
+void ProtoMsgCodec::encode(Message *msg, Buffer &buf) {
     size_t offset = buf.size();
-    buf.appendValue((uint32_t)0);
-    const string& typeName = msg->GetDescriptor()->full_name();
-    buf.appendValue((uint32_t)typeName.size());
+    buf.appendValue((uint32_t) 0);
+    const string &typeName = msg->GetDescriptor()->full_name();
+    buf.appendValue((uint32_t) typeName.size());
     buf.append(typeName.data(), typeName.size());
     msg->SerializeToArray(buf.allocRoom(msg->ByteSize()), msg->ByteSize());
-    *(uint32_t*)(buf.begin()+offset) = buf.size() - offset;
+    *(uint32_t *) (buf.begin() + offset) = buf.size() - offset;
 }
 
-}
+}  // namespace handy

--- a/protobuf/proto_msg.h
+++ b/protobuf/proto_msg.h
@@ -7,27 +7,27 @@ namespace handy {
 
 typedef ::google::protobuf::Message Message;
 typedef ::google::protobuf::Descriptor Descriptor;
-typedef std::function<void(TcpConnPtr con, Message* msg)> ProtoCallBack;
+typedef std::function<void(TcpConnPtr con, Message *msg)> ProtoCallBack;
 
 struct ProtoMsgCodec {
-    static void encode(Message* msg, Buffer& buf);
-    static Message* decode(Buffer& buf);
-    static bool msgComplete(Buffer& buf);
+    static void encode(Message *msg, Buffer &buf);
+    static Message *decode(Buffer &buf);
+    static bool msgComplete(Buffer &buf);
 };
 
 struct ProtoMsgDispatcher {
-    void handle(TcpConnPtr con, Message* msg);
-    template<typename M> void onMsg(std::function<void(TcpConnPtr con, M* msg)> cb) {
-        protocbs_[M::descriptor()] = [cb](TcpConnPtr con, Message* msg) {
-            cb(con, dynamic_cast<M*>( msg));
-        };
+    void handle(TcpConnPtr con, Message *msg);
+    template <typename M>
+    void onMsg(std::function<void(TcpConnPtr con, M *msg)> cb) {
+        protocbs_[M::descriptor()] = [cb](TcpConnPtr con, Message *msg) { cb(con, dynamic_cast<M *>(msg)); };
     }
-private:
-    std::map<const Descriptor*, ProtoCallBack> protocbs_;
+
+   private:
+    std::map<const Descriptor *, ProtoCallBack> protocbs_;
 };
 
-inline bool ProtoMsgCodec::msgComplete(Buffer& buf) {
-    return buf.size() >= 4 && buf.size() >= *(uint32_t*)buf.begin();
+inline bool ProtoMsgCodec::msgComplete(Buffer &buf) {
+    return buf.size() >= 4 && buf.size() >= *(uint32_t *) buf.begin();
 }
 
-}
+}  // namespace handy

--- a/protobuf/test.cc
+++ b/protobuf/test.cc
@@ -1,10 +1,10 @@
-#include "proto_msg.h"
 #include "msg.pb.h"
+#include "proto_msg.h"
 
 using namespace std;
 using namespace handy;
 
-void handleQuery(TcpConnPtr con, Query* query) {
+void handleQuery(TcpConnPtr con, Query *query) {
     info("query recved name %s id %d", query->name().c_str(), query->id());
     delete query;
     con->getBase()->exit();
@@ -17,7 +17,7 @@ void testencode() {
     Buffer b;
     ProtoMsgCodec dis;
     dis.encode(&q, b);
-    Query* p = dynamic_cast<Query*> (dis.decode(b));
+    Query *p = dynamic_cast<Query *>(dis.decode(b));
     info("p name %s id %d", p->name().c_str(), p->id());
     delete p;
 }
@@ -30,23 +30,21 @@ int main() {
     int r = echo.bind("", 2099);
     exitif(r, "bind failed %d %s", errno, strerror(errno));
     ProtoMsgDispatcher dispatch;
-    echo.onConnRead(
-        [&](TcpConnPtr con) {
-            if (ProtoMsgCodec::msgComplete(con->getInput())) {
-                Message* msg = ProtoMsgCodec::decode(con->getInput());
-                if (msg) {
-                    dispatch.handle(con, msg);
-                } else {
-                    error("bad msg from connection data");
-                    con->close();
-                }
+    echo.onConnRead([&](TcpConnPtr con) {
+        if (ProtoMsgCodec::msgComplete(con->getInput())) {
+            Message *msg = ProtoMsgCodec::decode(con->getInput());
+            if (msg) {
+                dispatch.handle(con, msg);
+            } else {
+                error("bad msg from connection data");
+                con->close();
             }
         }
-    );
+    });
 
     dispatch.onMsg<Query>(handleQuery);
     TcpConnPtr cmd = TcpConn::createConnection(&base, "localhost", 2099);
-    cmd->onState([](const TcpConnPtr& con) { 
+    cmd->onState([](const TcpConnPtr &con) {
         if (con->getState() == TcpConn::Connected) {
             Query query;
             query.set_name("hello", 5);

--- a/raw-examples/epoll-et.cc
+++ b/raw-examples/epoll-et.cc
@@ -4,31 +4,35 @@
  * 测试：curl -v localhost
  * 客户端发送GET请求后，服务器返回1M的数据，会触发EPOLLOUT，从epoll-et输出的日志看，EPOLLOUT事件得到了正确的处理
  */
-#include <sys/socket.h>
-#include <sys/epoll.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
 #include <errno.h>
-#include <string.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #include <map>
 #include <string>
-#include <signal.h>
 using namespace std;
-
 
 bool output_log = true;
 
-#define exit_if(r, ...) if(r) {printf(__VA_ARGS__); printf("%s:%d error no: %d error msg %s\n", __FILE__, __LINE__, errno, strerror(errno)); exit(1);}
+#define exit_if(r, ...)                                                                          \
+    if (r) {                                                                                     \
+        printf(__VA_ARGS__);                                                                     \
+        printf("%s:%d error no: %d error msg %s\n", __FILE__, __LINE__, errno, strerror(errno)); \
+        exit(1);                                                                                 \
+    }
 
 void setNonBlock(int fd) {
     int flags = fcntl(fd, F_GETFL, 0);
-    exit_if(flags<0, "fcntl failed");
+    exit_if(flags < 0, "fcntl failed");
     int r = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-    exit_if(r<0, "fcntl failed");
+    exit_if(r < 0, "fcntl failed");
 }
 
 void updateEvents(int efd, int fd, int events, int op) {
@@ -36,8 +40,7 @@ void updateEvents(int efd, int fd, int events, int op) {
     memset(&ev, 0, sizeof(ev));
     ev.events = events;
     ev.data.fd = fd;
-    printf("%s fd %d events read %d write %d\n",
-           op==EPOLL_CTL_MOD?"mod":"add", fd, ev.events & EPOLLIN, ev.events & EPOLLOUT);
+    printf("%s fd %d events read %d write %d\n", op == EPOLL_CTL_MOD ? "mod" : "add", fd, ev.events & EPOLLIN, ev.events & EPOLLOUT);
     int r = epoll_ctl(efd, op, fd, &ev);
     exit_if(r, "epoll_ctl failed");
 }
@@ -45,43 +48,44 @@ void updateEvents(int efd, int fd, int events, int op) {
 void handleAccept(int efd, int fd) {
     struct sockaddr_in raddr;
     socklen_t rsz = sizeof(raddr);
-    int cfd = accept(fd,(struct sockaddr *)&raddr,&rsz);
-    exit_if(cfd<0, "accept failed");
+    int cfd = accept(fd, (struct sockaddr *) &raddr, &rsz);
+    exit_if(cfd < 0, "accept failed");
     sockaddr_in peer, local;
     socklen_t alen = sizeof(peer);
-    int r = getpeername(cfd, (sockaddr*)&peer, &alen);
-    exit_if(r<0, "getpeername failed");
+    int r = getpeername(cfd, (sockaddr *) &peer, &alen);
+    exit_if(r < 0, "getpeername failed");
     printf("accept a connection from %s\n", inet_ntoa(raddr.sin_addr));
     setNonBlock(cfd);
-    updateEvents(efd, cfd, EPOLLIN|EPOLLOUT|EPOLLET, EPOLL_CTL_ADD);
+    updateEvents(efd, cfd, EPOLLIN | EPOLLOUT | EPOLLET, EPOLL_CTL_ADD);
 }
 struct Con {
     string readed;
     size_t written;
-    Con(): written(0) {}
+    Con() : written(0) {}
 };
 map<int, Con> cons;
 
 string httpRes;
 void sendRes(int fd) {
-    Con& con = cons[fd];
+    Con &con = cons[fd];
     if (!con.readed.length())
         return;
     size_t left = httpRes.length() - con.written;
     int wd = 0;
-    while((wd=::write(fd, httpRes.data()+con.written, left))>0) {
+    while ((wd = ::write(fd, httpRes.data() + con.written, left)) > 0) {
         con.written += wd;
         left -= wd;
-        if(output_log) printf("write %d bytes left: %lu\n", wd, left);
+        if (output_log)
+            printf("write %d bytes left: %lu\n", wd, left);
     };
     if (left == 0) {
-//        close(fd); // 测试中使用了keepalive，因此不关闭连接。连接会在read事件中关闭
+        //        close(fd); // 测试中使用了keepalive，因此不关闭连接。连接会在read事件中关闭
         cons.erase(fd);
         return;
     }
-    if (wd < 0 &&  (errno == EAGAIN || errno == EWOULDBLOCK))
+    if (wd < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
         return;
-    if (wd<=0) {
+    if (wd <= 0) {
         printf("write error for %d: %d %s\n", fd, errno, strerror(errno));
         close(fd);
         cons.erase(fd);
@@ -91,18 +95,19 @@ void sendRes(int fd) {
 void handleRead(int efd, int fd) {
     char buf[4096];
     int n = 0;
-    while ((n=::read(fd, buf, sizeof buf)) > 0) {
-        if(output_log) printf("read %d bytes\n", n);
-        string& readed = cons[fd].readed;
+    while ((n = ::read(fd, buf, sizeof buf)) > 0) {
+        if (output_log)
+            printf("read %d bytes\n", n);
+        string &readed = cons[fd].readed;
         readed.append(buf, n);
-        if (readed.length()>4) {
-            if (readed.substr(readed.length()-2, 2) == "\n\n" || readed.substr(readed.length()-4, 4) == "\r\n\r\n") {
+        if (readed.length() > 4) {
+            if (readed.substr(readed.length() - 2, 2) == "\n\n" || readed.substr(readed.length() - 4, 4) == "\r\n\r\n") {
                 //当读取到一个完整的http请求，测试发送响应
                 sendRes(fd);
             }
         }
     }
-    if (n<0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
         return;
     //实际应用中，n<0应当检查各类错误，如EINTR
     if (n < 0) {
@@ -120,8 +125,9 @@ void loop_once(int efd, int lfd, int waitms) {
     const int kMaxEvents = 20;
     struct epoll_event activeEvs[100];
     int n = epoll_wait(efd, activeEvs, kMaxEvents, waitms);
-    if(output_log) printf("epoll_wait return %d\n", n);
-    for (int i = 0; i < n; i ++) {
+    if (output_log)
+        printf("epoll_wait return %d\n", n);
+    for (int i = 0; i < n; i++) {
         int fd = activeEvs[i].data.fd;
         int events = activeEvs[i].events;
         if (events & (EPOLLIN | EPOLLERR)) {
@@ -131,7 +137,8 @@ void loop_once(int efd, int lfd, int waitms) {
                 handleRead(efd, fd);
             }
         } else if (events & EPOLLOUT) {
-            if(output_log) printf("handling epollout\n");
+            if (output_log)
+                printf("handling epollout\n");
             handleWrite(efd, fd);
         } else {
             exit_if(1, "unknown event");
@@ -139,12 +146,14 @@ void loop_once(int efd, int lfd, int waitms) {
     }
 }
 
-int main(int argc, const char* argv[]) {
-    if (argc > 1) { output_log = false; }
+int main(int argc, const char *argv[]) {
+    if (argc > 1) {
+        output_log = false;
+    }
     ::signal(SIGPIPE, SIG_IGN);
     httpRes = "HTTP/1.1 200 OK\r\nConnection: Keep-Alive\r\nContent-Type: text/html; charset=UTF-8\r\nContent-Length: 1048576\r\n\r\n123456";
-    for(int i=0;i<1048570;i++) {
-        httpRes+='\0';
+    for (int i = 0; i < 1048570; i++) {
+        httpRes += '\0';
     }
     short port = 80;
     int epollfd = epoll_create(1);
@@ -156,14 +165,14 @@ int main(int argc, const char* argv[]) {
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = INADDR_ANY;
-    int r = ::bind(listenfd,(struct sockaddr *)&addr, sizeof(struct sockaddr));
+    int r = ::bind(listenfd, (struct sockaddr *) &addr, sizeof(struct sockaddr));
     exit_if(r, "bind to 0.0.0.0:%d failed %d %s", port, errno, strerror(errno));
     r = listen(listenfd, 20);
     exit_if(r, "listen failed %d %s", errno, strerror(errno));
     printf("fd %d listening at %d\n", listenfd, port);
     setNonBlock(listenfd);
     updateEvents(epollfd, listenfd, EPOLLIN, EPOLL_CTL_ADD);
-    for (;;) { //实际应用应当注册信号处理函数，退出时清理资源
+    for (;;) {  //实际应用应当注册信号处理函数，退出时清理资源
         loop_once(epollfd, listenfd, 10000);
     }
     return 0;

--- a/raw-examples/epoll.cc
+++ b/raw-examples/epoll.cc
@@ -3,31 +3,35 @@
  * 运行： ./epoll
  * 测试：curl -v localhost
  */
-#include <sys/socket.h>
-#include <sys/epoll.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
 #include <errno.h>
-#include <string.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <signal.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #include <map>
 #include <string>
-#include <signal.h>
 using namespace std;
-
 
 bool output_log = true;
 
-#define exit_if(r, ...) if(r) {printf(__VA_ARGS__); printf("%s:%d error no: %d error msg %s\n", __FILE__, __LINE__, errno, strerror(errno)); exit(1);}
+#define exit_if(r, ...)                                                                          \
+    if (r) {                                                                                     \
+        printf(__VA_ARGS__);                                                                     \
+        printf("%s:%d error no: %d error msg %s\n", __FILE__, __LINE__, errno, strerror(errno)); \
+        exit(1);                                                                                 \
+    }
 
 void setNonBlock(int fd) {
     int flags = fcntl(fd, F_GETFL, 0);
-    exit_if(flags<0, "fcntl failed");
+    exit_if(flags < 0, "fcntl failed");
     int r = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-    exit_if(r<0, "fcntl failed");
+    exit_if(r < 0, "fcntl failed");
 }
 
 void updateEvents(int efd, int fd, int events, int op) {
@@ -35,8 +39,7 @@ void updateEvents(int efd, int fd, int events, int op) {
     memset(&ev, 0, sizeof(ev));
     ev.events = events;
     ev.data.fd = fd;
-    printf("%s fd %d events read %d write %d\n",
-           op==EPOLL_CTL_MOD?"mod":"add", fd, ev.events & EPOLLIN, ev.events & EPOLLOUT);
+    printf("%s fd %d events read %d write %d\n", op == EPOLL_CTL_MOD ? "mod" : "add", fd, ev.events & EPOLLIN, ev.events & EPOLLOUT);
     int r = epoll_ctl(efd, op, fd, &ev);
     exit_if(r, "epoll_ctl failed");
 }
@@ -44,12 +47,12 @@ void updateEvents(int efd, int fd, int events, int op) {
 void handleAccept(int efd, int fd) {
     struct sockaddr_in raddr;
     socklen_t rsz = sizeof(raddr);
-    int cfd = accept(fd,(struct sockaddr *)&raddr,&rsz);
-    exit_if(cfd<0, "accept failed");
+    int cfd = accept(fd, (struct sockaddr *) &raddr, &rsz);
+    exit_if(cfd < 0, "accept failed");
     sockaddr_in peer, local;
     socklen_t alen = sizeof(peer);
-    int r = getpeername(cfd, (sockaddr*)&peer, &alen);
-    exit_if(r<0, "getpeername failed");
+    int r = getpeername(cfd, (sockaddr *) &peer, &alen);
+    exit_if(r < 0, "getpeername failed");
     printf("accept a connection from %s\n", inet_ntoa(raddr.sin_addr));
     setNonBlock(cfd);
     updateEvents(efd, cfd, EPOLLIN, EPOLL_CTL_ADD);
@@ -58,37 +61,38 @@ struct Con {
     string readed;
     size_t written;
     bool writeEnabled;
-    Con(): written(0), writeEnabled(false) {}
+    Con() : written(0), writeEnabled(false) {}
 };
 map<int, Con> cons;
 
 string httpRes;
 void sendRes(int efd, int fd) {
-    Con& con = cons[fd];
+    Con &con = cons[fd];
     size_t left = httpRes.length() - con.written;
     int wd = 0;
-    while((wd=::write(fd, httpRes.data()+con.written, left))>0) {
+    while ((wd = ::write(fd, httpRes.data() + con.written, left)) > 0) {
         con.written += wd;
         left -= wd;
-        if(output_log) printf("write %d bytes left: %lu\n", wd, left);
+        if (output_log)
+            printf("write %d bytes left: %lu\n", wd, left);
     };
     if (left == 0) {
-//        close(fd); // 测试中使用了keepalive，因此不关闭连接。连接会在read事件中关闭
+        //        close(fd); // 测试中使用了keepalive，因此不关闭连接。连接会在read事件中关闭
         if (con.writeEnabled) {
-            updateEvents(efd, fd, EPOLLIN, EPOLL_CTL_MOD); // 当所有数据发送结束后，不再关注其缓冲区可写事件
+            updateEvents(efd, fd, EPOLLIN, EPOLL_CTL_MOD);  // 当所有数据发送结束后，不再关注其缓冲区可写事件
             con.writeEnabled = false;
         }
         cons.erase(fd);
         return;
     }
-    if (wd < 0 &&  (errno == EAGAIN || errno == EWOULDBLOCK)) {
+    if (wd < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
         if (!con.writeEnabled) {
-            updateEvents(efd, fd, EPOLLIN|EPOLLOUT, EPOLL_CTL_MOD);
+            updateEvents(efd, fd, EPOLLIN | EPOLLOUT, EPOLL_CTL_MOD);
             con.writeEnabled = true;
         }
         return;
     }
-    if (wd<=0) {
+    if (wd <= 0) {
         printf("write error for %d: %d %s\n", fd, errno, strerror(errno));
         close(fd);
         cons.erase(fd);
@@ -98,18 +102,19 @@ void sendRes(int efd, int fd) {
 void handleRead(int efd, int fd) {
     char buf[4096];
     int n = 0;
-    while ((n=::read(fd, buf, sizeof buf)) > 0) {
-        if(output_log) printf("read %d bytes\n", n);
-        string& readed = cons[fd].readed;
+    while ((n = ::read(fd, buf, sizeof buf)) > 0) {
+        if (output_log)
+            printf("read %d bytes\n", n);
+        string &readed = cons[fd].readed;
         readed.append(buf, n);
-        if (readed.length()>4) {
-            if (readed.substr(readed.length()-2, 2) == "\n\n" || readed.substr(readed.length()-4, 4) == "\r\n\r\n") {
+        if (readed.length() > 4) {
+            if (readed.substr(readed.length() - 2, 2) == "\n\n" || readed.substr(readed.length() - 4, 4) == "\r\n\r\n") {
                 //当读取到一个完整的http请求，测试发送响应
                 sendRes(efd, fd);
             }
         }
     }
-    if (n<0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
         return;
     //实际应用中，n<0应当检查各类错误，如EINTR
     if (n < 0) {
@@ -127,8 +132,9 @@ void loop_once(int efd, int lfd, int waitms) {
     const int kMaxEvents = 20;
     struct epoll_event activeEvs[100];
     int n = epoll_wait(efd, activeEvs, kMaxEvents, waitms);
-    if(output_log) printf("epoll_wait return %d\n", n);
-    for (int i = 0; i < n; i ++) {
+    if (output_log)
+        printf("epoll_wait return %d\n", n);
+    for (int i = 0; i < n; i++) {
         int fd = activeEvs[i].data.fd;
         int events = activeEvs[i].events;
         if (events & (EPOLLIN | EPOLLERR)) {
@@ -138,7 +144,8 @@ void loop_once(int efd, int lfd, int waitms) {
                 handleRead(efd, fd);
             }
         } else if (events & EPOLLOUT) {
-            if(output_log) printf("handling epollout\n");
+            if (output_log)
+                printf("handling epollout\n");
             handleWrite(efd, fd);
         } else {
             exit_if(1, "unknown event");
@@ -146,12 +153,14 @@ void loop_once(int efd, int lfd, int waitms) {
     }
 }
 
-int main(int argc, const char* argv[]) {
-    if (argc > 1) { output_log = false; }
+int main(int argc, const char *argv[]) {
+    if (argc > 1) {
+        output_log = false;
+    }
     ::signal(SIGPIPE, SIG_IGN);
     httpRes = "HTTP/1.1 200 OK\r\nConnection: Keep-Alive\r\nContent-Type: text/html; charset=UTF-8\r\nContent-Length: 1048576\r\n\r\n123456";
-    for(int i=0;i<1048570;i++) {
-        httpRes+='\0';
+    for (int i = 0; i < 1048570; i++) {
+        httpRes += '\0';
     }
     short port = 80;
     int epollfd = epoll_create(1);
@@ -163,14 +172,14 @@ int main(int argc, const char* argv[]) {
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = INADDR_ANY;
-    int r = ::bind(listenfd,(struct sockaddr *)&addr, sizeof(struct sockaddr));
+    int r = ::bind(listenfd, (struct sockaddr *) &addr, sizeof(struct sockaddr));
     exit_if(r, "bind to 0.0.0.0:%d failed %d %s", port, errno, strerror(errno));
     r = listen(listenfd, 20);
     exit_if(r, "listen failed %d %s", errno, strerror(errno));
     printf("fd %d listening at %d\n", listenfd, port);
     setNonBlock(listenfd);
     updateEvents(epollfd, listenfd, EPOLLIN, EPOLL_CTL_ADD);
-    for (;;) { //实际应用应当注册信号处理函数，退出时清理资源
+    for (;;) {  //实际应用应当注册信号处理函数，退出时清理资源
         loop_once(epollfd, listenfd, 10000);
     }
     return 0;

--- a/raw-examples/kqueue.cc
+++ b/raw-examples/kqueue.cc
@@ -5,44 +5,48 @@
  * 结果：abc
  * 例子的echo返回了 abc
  */
-#include <sys/socket.h>
-#include <sys/event.h>
-#include <netinet/in.h>
 #include <arpa/inet.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <stdio.h>
 #include <errno.h>
-#include <string.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/event.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
-#define exit_if(r, ...) if(r) {printf(__VA_ARGS__); printf("error no: %d error msg %s\n", errno, strerror(errno)); exit(1);}
+#define exit_if(r, ...)                                                \
+    if (r) {                                                           \
+        printf(__VA_ARGS__);                                           \
+        printf("error no: %d error msg %s\n", errno, strerror(errno)); \
+        exit(1);                                                       \
+    }
 
 const int kReadEvent = 1;
 const int kWriteEvent = 2;
 
 void setNonBlock(int fd) {
     int flags = fcntl(fd, F_GETFL, 0);
-    exit_if(flags<0, "fcntl failed");
+    exit_if(flags < 0, "fcntl failed");
     int r = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
-    exit_if(r<0, "fcntl failed");
+    exit_if(r < 0, "fcntl failed");
 }
 
 void updateEvents(int efd, int fd, int events, bool modify) {
     struct kevent ev[2];
     int n = 0;
     if (events & kReadEvent) {
-        EV_SET(&ev[n++], fd, EVFILT_READ, EV_ADD|EV_ENABLE, 0, 0, (void*)(intptr_t)fd);
-    } else if (modify){
-        EV_SET(&ev[n++], fd, EVFILT_READ, EV_DELETE, 0, 0, (void*)(intptr_t)fd);
+        EV_SET(&ev[n++], fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, (void *) (intptr_t) fd);
+    } else if (modify) {
+        EV_SET(&ev[n++], fd, EVFILT_READ, EV_DELETE, 0, 0, (void *) (intptr_t) fd);
     }
     if (events & kWriteEvent) {
-        EV_SET(&ev[n++], fd, EVFILT_WRITE, EV_ADD|EV_ENABLE, 0, 0, (void*)(intptr_t)fd);
-    } else if (modify){
-        EV_SET(&ev[n++], fd, EVFILT_WRITE, EV_DELETE, 0, 0, (void*)(intptr_t)fd);
+        EV_SET(&ev[n++], fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, (void *) (intptr_t) fd);
+    } else if (modify) {
+        EV_SET(&ev[n++], fd, EVFILT_WRITE, EV_DELETE, 0, 0, (void *) (intptr_t) fd);
     }
-    printf("%s fd %d events read %d write %d\n",
-           modify ? "mod" : "add", fd, events & kReadEvent, events & kWriteEvent);
+    printf("%s fd %d events read %d write %d\n", modify ? "mod" : "add", fd, events & kReadEvent, events & kWriteEvent);
     int r = kevent(efd, ev, n, NULL, 0, NULL);
     exit_if(r, "kevent failed ");
 }
@@ -50,29 +54,29 @@ void updateEvents(int efd, int fd, int events, bool modify) {
 void handleAccept(int efd, int fd) {
     struct sockaddr_in raddr;
     socklen_t rsz = sizeof(raddr);
-    int cfd = accept(fd,(struct sockaddr *)&raddr,&rsz);
-    exit_if(cfd<0, "accept failed");
+    int cfd = accept(fd, (struct sockaddr *) &raddr, &rsz);
+    exit_if(cfd < 0, "accept failed");
     sockaddr_in peer, local;
     socklen_t alen = sizeof(peer);
-    int r = getpeername(cfd, (sockaddr*)&peer, &alen);
-    exit_if(r<0, "getpeername failed");
+    int r = getpeername(cfd, (sockaddr *) &peer, &alen);
+    exit_if(r < 0, "getpeername failed");
     printf("accept a connection from %s\n", inet_ntoa(raddr.sin_addr));
     setNonBlock(cfd);
-    updateEvents(efd, cfd, kReadEvent|kWriteEvent, false);
+    updateEvents(efd, cfd, kReadEvent | kWriteEvent, false);
 }
 
 void handleRead(int efd, int fd) {
     char buf[4096];
     int n = 0;
-    while ((n=::read(fd, buf, sizeof buf)) > 0) {
+    while ((n = ::read(fd, buf, sizeof buf)) > 0) {
         printf("read %d bytes\n", n);
-        int r = ::write(fd, buf, n); //写出读取的数据
+        int r = ::write(fd, buf, n);  //写出读取的数据
         //实际应用中，写出数据可能会返回EAGAIN，此时应当监听可写事件，当可写时再把数据写出
-        exit_if(r<=0, "write error");
+        exit_if(r <= 0, "write error");
     }
-    if (n<0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
         return;
-    exit_if(n<0, "read error"); //实际应用中，n<0应当检查各类错误，如EINTR
+    exit_if(n < 0, "read error");  //实际应用中，n<0应当检查各类错误，如EINTR
     printf("fd %d closed\n", fd);
     close(fd);
 }
@@ -90,8 +94,8 @@ void loop_once(int efd, int lfd, int waitms) {
     struct kevent activeEvs[kMaxEvents];
     int n = kevent(efd, NULL, 0, activeEvs, kMaxEvents, &timeout);
     printf("kqueue return %d\n", n);
-    for (int i = 0; i < n; i ++) {
-        int fd = (int)(intptr_t)activeEvs[i].udata;
+    for (int i = 0; i < n; i++) {
+        int fd = (int) (intptr_t) activeEvs[i].udata;
         int events = activeEvs[i].filter;
         if (events == EVFILT_READ) {
             if (fd == lfd) {
@@ -118,14 +122,14 @@ int main() {
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = INADDR_ANY;
-    int r = ::bind(listenfd,(struct sockaddr *)&addr, sizeof(struct sockaddr));
+    int r = ::bind(listenfd, (struct sockaddr *) &addr, sizeof(struct sockaddr));
     exit_if(r, "bind to 0.0.0.0:%d failed %d %s", port, errno, strerror(errno));
     r = listen(listenfd, 20);
     exit_if(r, "listen failed %d %s", errno, strerror(errno));
     printf("fd %d listening at %d\n", listenfd, port);
     setNonBlock(listenfd);
     updateEvents(epollfd, listenfd, kReadEvent, false);
-    for (;;) { //实际应用应当注册信号处理函数，退出时清理资源
+    for (;;) {  //实际应用应当注册信号处理函数，退出时清理资源
         loop_once(epollfd, listenfd, 10000);
     }
     return 0;

--- a/test/conf.ut.cc
+++ b/test/conf.ut.cc
@@ -5,17 +5,17 @@
 using namespace std;
 using namespace handy;
 
-int dump_ini(const char* dir, const char* inifile) {
+int dump_ini(const char *dir, const char *inifile) {
     Conf conf;
     char buf[4096];
     snprintf(buf, sizeof buf, "%s/%s", dir, inifile);
     int err = conf.parse(buf);
     if (err) {
-        //printf("parse error in %s err: %d\n", inifile, err);
+        // printf("parse error in %s err: %d\n", inifile, err);
         return err;
     }
-    //printf("file %s:\n", inifile);
-    //for (auto& kv : conf.values_) {
+    // printf("file %s:\n", inifile);
+    // for (auto& kv : conf.values_) {
     //    for(auto& v : kv.second) {
     //        printf("%s=%s\n", kv.first.c_str(), v.c_str());
     //    }
@@ -24,7 +24,7 @@ int dump_ini(const char* dir, const char* inifile) {
 }
 
 TEST(test::TestBase, allFiles) {
-    const char* dir = "test/";
+    const char *dir = "test/";
     ASSERT_EQ(1, dump_ini(dir, "files/bad_comment.ini"));
     ASSERT_EQ(1, dump_ini(dir, "files/bad_multi.ini"));
     ASSERT_EQ(3, dump_ini(dir, "files/bad_section.ini"));
@@ -32,4 +32,3 @@ TEST(test::TestBase, allFiles) {
     ASSERT_EQ(0, dump_ini(dir, "files/normal.ini"));
     ASSERT_EQ(0, dump_ini(dir, "files/user_error.ini"));
 }
-

--- a/test/handy.ut.cc
+++ b/test/handy.ut.cc
@@ -1,7 +1,7 @@
 #include <handy/conn.h>
 #include <handy/logging.h>
-#include "test_harness.h"
 #include <thread>
+#include "test_harness.h"
 
 using namespace std;
 using namespace handy;
@@ -15,10 +15,12 @@ TEST(test::TestBase, Ip4Addr) {
 
 TEST(test::TestBase, EventBase) {
     EventBase base;
-    base.safeCall([] {
-        info("task by base.addTask");
+    base.safeCall([] { info("task by base.addTask"); });
+    thread th([&] {
+        usleep(50000);
+        info("base exit");
+        base.exit();
     });
-    thread th([&]{ usleep(50000); info("base exit"); base.exit(); });
     base.loop();
     th.join();
 }
@@ -27,15 +29,15 @@ TEST(test::TestBase, Timer) {
     EventBase base;
     long now = util::timeMilli();
     info("adding timers ");
-    TimerId tid1 = base.runAt(now + 100, []{info("timer at 100");});
-    TimerId tid2 = base.runAfter(50, []{ info("timer after 50"); });
-    TimerId tid3 = base.runAfter(20, [] { info("timer interval 10");}, 10);
+    TimerId tid1 = base.runAt(now + 100, [] { info("timer at 100"); });
+    TimerId tid2 = base.runAfter(50, [] { info("timer after 50"); });
+    TimerId tid3 = base.runAfter(20, [] { info("timer interval 10"); }, 10);
     base.runAfter(120, [&] {
         info("after 120 then cancel above");
         base.cancel(tid1);
         base.cancel(tid2);
         base.cancel(tid3);
-        base.exit(); 
+        base.exit();
     });
     base.loop();
 }
@@ -46,21 +48,19 @@ TEST(test::TestBase, TcpServer1) {
     TcpServer delayEcho(&base);
     int r = delayEcho.bind("", 2099);
     ASSERT_EQ(r, 0);
-    delayEcho.onConnRead(
-        [&th, &base](const TcpConnPtr& con) {
-            th.addTask([&base,con] { 
-                usleep(200*1000);
-                info("in pool"); 
-                base.safeCall([con, &base]{
-                    con->send(con->getInput());
-                    base.exit();
-                });
+    delayEcho.onConnRead([&th, &base](const TcpConnPtr &con) {
+        th.addTask([&base, con] {
+            usleep(200 * 1000);
+            info("in pool");
+            base.safeCall([con, &base] {
+                con->send(con->getInput());
+                base.exit();
             });
-            con->close();
-        }
-    );
+        });
+        con->close();
+    });
     TcpConnPtr con = TcpConn::createConnection(&base, "localhost", 2099);
-    con->onState([](const TcpConnPtr& con) {
+    con->onState([](const TcpConnPtr &con) {
         if (con->getState() == TcpConn::Connected)
             con->send("hello");
     });
@@ -74,14 +74,15 @@ TEST(test::TestBase, kevent) {
     TcpServer echo(&base);
     int r = echo.bind("", 2099);
     ASSERT_EQ(r, 0);
-    echo.onConnRead([](const TcpConnPtr& con) {
-        con->send(con->getInput());
-    });
+    echo.onConnRead([](const TcpConnPtr &con) { con->send(con->getInput()); });
     TcpConnPtr con = TcpConn::createConnection(&base, "localhost", 2099);
-    con->onState([](const TcpConnPtr& con) {
+    con->onState([](const TcpConnPtr &con) {
         if (con->getState() == TcpConn::Connected)
             con->send("hello");
     });
-    base.runAfter(5, [con, &base]{con->closeNow(); base.exit(); });
+    base.runAfter(5, [con, &base] {
+        con->closeNow();
+        base.exit();
+    });
     base.loop();
 }

--- a/test/tcpcli.ut.cc
+++ b/test/tcpcli.ut.cc
@@ -5,25 +5,21 @@
 using namespace std;
 using namespace handy;
 
-TcpConnPtr connectto(EventBase* base, const char* host, short port) {
+TcpConnPtr connectto(EventBase *base, const char *host, short port) {
     TcpConnPtr con1 = TcpConn::createConnection(base, host, port);
-    con1->onState(
-        [=](const TcpConnPtr con) {
-            if (con->getState() == TcpConn::Connected) {
-                con->send("GET / HTTP/1.1\r\n\r\n");
-            } else if (con->getState() == TcpConn::Closed) {
-                info("connection to %s %d closed", host, port);
-            } else if (con->getState() == TcpConn::Failed) {
-                info("connect to %s %d failed", host, port);
-            }
-    }
-    );
-    con1->onRead( 
-        [=](const TcpConnPtr con) {
-            printf("%s %d response length is %lu bytes\n", host, port, con->getInput().size());
-            con->getInput().clear();
-    }
-    );
+    con1->onState([=](const TcpConnPtr con) {
+        if (con->getState() == TcpConn::Connected) {
+            con->send("GET / HTTP/1.1\r\n\r\n");
+        } else if (con->getState() == TcpConn::Closed) {
+            info("connection to %s %d closed", host, port);
+        } else if (con->getState() == TcpConn::Failed) {
+            info("connect to %s %d failed", host, port);
+        }
+    });
+    con1->onRead([=](const TcpConnPtr con) {
+        printf("%s %d response length is %lu bytes\n", host, port, con->getInput().size());
+        con->getInput().clear();
+    });
     return con1;
 }
 
@@ -32,10 +28,10 @@ TEST(test::TestBase, tcpcli) {
     TcpConnPtr baidu = connectto(&base, "www.baidu.com", 80);
     TcpConnPtr c = connectto(&base, "www.baidu.com", 81);
     TcpConnPtr local = connectto(&base, "localhost", 10000);
-    for (int i = 0; i < 5; i ++) {
+    for (int i = 0; i < 5; i++) {
         base.loop_once(50);
     }
-    //ASSERT_EQ(TcpConn::Connected, baidu->getState());
+    // ASSERT_EQ(TcpConn::Connected, baidu->getState());
     ASSERT_EQ(TcpConn::Handshaking, c->getState());
     ASSERT_EQ(TcpConn::Failed, local->getState());
 }

--- a/test/test_harness.cc
+++ b/test/test_harness.cc
@@ -1,10 +1,10 @@
 #include "test_harness.h"
 
-#include <string>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <string>
 #include <vector>
 
 namespace handy {
@@ -12,53 +12,53 @@ namespace test {
 
 namespace {
 struct Test {
-  const char* base;
-  const char* name;
-  void (*func)();
+    const char *base;
+    const char *name;
+    void (*func)();
 };
-std::vector<Test>* tests;
-}
+std::vector<Test> *tests;
+}  // namespace
 
-bool RegisterTest(const char* base, const char* name, void (*func)()) {
-  if (tests == NULL) {
-    tests = new std::vector<Test>;
-  }
-  Test t;
-  t.base = base;
-  t.name = name;
-  t.func = func;
-  tests->push_back(t);
-  return true;
-}
-
-int RunAllTests(const char* matcher) {
-  int num = 0;
-  if (tests != NULL) {
-    for (size_t i = 0; i < tests->size(); i++) {
-      const Test& t = (*tests)[i];
-      if (matcher != NULL) {
-        std::string name = t.base;
-        name.push_back('.');
-        name.append(t.name);
-        if (strstr(name.c_str(), matcher) == NULL) {
-          continue;
-        }
-      }
-      fprintf(stderr, "==== Test %s.%s\n", t.base, t.name);
-      (*t.func)();
-      ++num;
+bool RegisterTest(const char *base, const char *name, void (*func)()) {
+    if (tests == NULL) {
+        tests = new std::vector<Test>;
     }
-  }
-  fprintf(stderr, "==== PASSED %d tests\n", num);
-  return 0;
+    Test t;
+    t.base = base;
+    t.name = name;
+    t.func = func;
+    tests->push_back(t);
+    return true;
+}
+
+int RunAllTests(const char *matcher) {
+    int num = 0;
+    if (tests != NULL) {
+        for (size_t i = 0; i < tests->size(); i++) {
+            const Test &t = (*tests)[i];
+            if (matcher != NULL) {
+                std::string name = t.base;
+                name.push_back('.');
+                name.append(t.name);
+                if (strstr(name.c_str(), matcher) == NULL) {
+                    continue;
+                }
+            }
+            fprintf(stderr, "==== Test %s.%s\n", t.base, t.name);
+            (*t.func)();
+            ++num;
+        }
+    }
+    fprintf(stderr, "==== PASSED %d tests\n", num);
+    return 0;
 }
 
 std::string TmpDir() {
-  return "/tmp";
+    return "/tmp";
 }
 
 int RandomSeed() {
-  return 301;
+    return 301;
 }
 
 }  // namespace test

--- a/test/test_harness.h
+++ b/test/test_harness.h
@@ -17,7 +17,7 @@ namespace test {
 //
 // Returns 0 if all tests pass.
 // Dies or returns a non-zero value if some test fails.
-extern int RunAllTests(const char* matcher);
+extern int RunAllTests(const char *matcher);
 
 // Return the directory to use for temporary storage.
 extern std::string TmpDir();
@@ -30,88 +30,85 @@ extern int RandomSeed();
 // An instance of Tester is allocated to hold temporary state during
 // the execution of an assertion.
 class Tester {
- private:
-  bool ok_;
-  const char* fname_;
-  int line_;
-  std::stringstream ss_;
+   private:
+    bool ok_;
+    const char *fname_;
+    int line_;
+    std::stringstream ss_;
 
- public:
-  Tester(const char* f, int l)
-      : ok_(true), fname_(f), line_(l) {
-  }
+   public:
+    Tester(const char *f, int l) : ok_(true), fname_(f), line_(l) {}
 
-  ~Tester() {
-    if (!ok_) {
-      fprintf(stderr, "%s:%d:%s\n", fname_, line_, ss_.str().c_str());
-      exit(1);
+    ~Tester() {
+        if (!ok_) {
+            fprintf(stderr, "%s:%d:%s\n", fname_, line_, ss_.str().c_str());
+            exit(1);
+        }
     }
-  }
 
-  Tester& Is(bool b, const char* msg) {
-    if (!b) {
-      ss_ << " Assertion failure " << msg;
-      ok_ = false;
+    Tester &Is(bool b, const char *msg) {
+        if (!b) {
+            ss_ << " Assertion failure " << msg;
+            ok_ = false;
+        }
+        return *this;
     }
-    return *this;
-  }
 
-#define BINARY_OP(name,op)                              \
-  template <class X, class Y>                           \
-  Tester& name(const X& x, const Y& y) {                \
-    if (! (x op y)) {                                   \
-      ss_ << " failed: " << x << (" " #op " ") << y;    \
-      ok_ = false;                                      \
-    }                                                   \
-    return *this;                                       \
-  }
+#define BINARY_OP(name, op)                                \
+    template <class X, class Y>                            \
+    Tester &name(const X &x, const Y &y) {                 \
+        if (!(x op y)) {                                   \
+            ss_ << " failed: " << x << (" " #op " ") << y; \
+            ok_ = false;                                   \
+        }                                                  \
+        return *this;                                      \
+    }
 
-  BINARY_OP(IsEq, ==)
-  BINARY_OP(IsNe, !=)
-  BINARY_OP(IsGe, >=)
-  BINARY_OP(IsGt, >)
-  BINARY_OP(IsLe, <=)
-  BINARY_OP(IsLt, <)
+    BINARY_OP(IsEq, ==)
+    BINARY_OP(IsNe, !=)
+    BINARY_OP(IsGe, >=)
+    BINARY_OP(IsGt, >)
+    BINARY_OP(IsLe, <=)
+    BINARY_OP(IsLt, <)
 #undef BINARY_OP
 
-  // Attach the specified value to the error message if an error has occurred
-  template <class V>
-  Tester& operator<<(const V& value) {
-    if (!ok_) {
-      ss_ << " " << value;
+    // Attach the specified value to the error message if an error has occurred
+    template <class V>
+    Tester &operator<<(const V &value) {
+        if (!ok_) {
+            ss_ << " " << value;
+        }
+        return *this;
     }
-    return *this;
-  }
 };
 
 #define ASSERT_TRUE(c) ::handy::test::Tester(__FILE__, __LINE__).Is((c), #c)
 #define ASSERT_FALSE(c) ::handy::test::Tester(__FILE__, __LINE__).Is(!(c), #c)
-#define ASSERT_EQ(a,b) ::handy::test::Tester(__FILE__, __LINE__).IsEq((a),(b))
-#define ASSERT_NE(a,b) ::handy::test::Tester(__FILE__, __LINE__).IsNe((a),(b))
-#define ASSERT_GE(a,b) ::handy::test::Tester(__FILE__, __LINE__).IsGe((a),(b))
-#define ASSERT_GT(a,b) ::handy::test::Tester(__FILE__, __LINE__).IsGt((a),(b))
-#define ASSERT_LE(a,b) ::handy::test::Tester(__FILE__, __LINE__).IsLe((a),(b))
-#define ASSERT_LT(a,b) ::handy::test::Tester(__FILE__, __LINE__).IsLt((a),(b))
+#define ASSERT_EQ(a, b) ::handy::test::Tester(__FILE__, __LINE__).IsEq((a), (b))
+#define ASSERT_NE(a, b) ::handy::test::Tester(__FILE__, __LINE__).IsNe((a), (b))
+#define ASSERT_GE(a, b) ::handy::test::Tester(__FILE__, __LINE__).IsGe((a), (b))
+#define ASSERT_GT(a, b) ::handy::test::Tester(__FILE__, __LINE__).IsGt((a), (b))
+#define ASSERT_LE(a, b) ::handy::test::Tester(__FILE__, __LINE__).IsLe((a), (b))
+#define ASSERT_LT(a, b) ::handy::test::Tester(__FILE__, __LINE__).IsLt((a), (b))
 
-#define TCONCAT(a,b) TCONCAT1(a,b)
-#define TCONCAT1(a,b) a##b
+#define TCONCAT(a, b) TCONCAT1(a, b)
+#define TCONCAT1(a, b) a##b
 
-#define TEST(base,name)                                                 \
-class TCONCAT(_Test_,name) : public base {                              \
- public:                                                                \
-  void _Run();                                                          \
-  static void _RunIt() {                                                \
-    TCONCAT(_Test_,name) t;                                             \
-    t._Run();                                                           \
-  }                                                                     \
-};                                                                      \
-bool TCONCAT(_Test_ignored_,name) =                                     \
-  ::handy::test::RegisterTest(#base, #name, &TCONCAT(_Test_,name)::_RunIt); \
-void TCONCAT(_Test_,name)::_Run()
+#define TEST(base, name)                                                                                            \
+    class TCONCAT(_Test_, name) : public base {                                                                     \
+       public:                                                                                                      \
+        void _Run();                                                                                                \
+        static void _RunIt() {                                                                                      \
+            TCONCAT(_Test_, name) t;                                                                                \
+            t._Run();                                                                                               \
+        }                                                                                                           \
+    };                                                                                                              \
+    bool TCONCAT(_Test_ignored_, name) = ::handy::test::RegisterTest(#base, #name, &TCONCAT(_Test_, name)::_RunIt); \
+    void TCONCAT(_Test_, name)::_Run()
 
 // Register the specified test.  Typically not used directly, but
 // invoked via the macro expansion of TEST.
-extern bool RegisterTest(const char* base, const char* name, void (*func)());
+extern bool RegisterTest(const char *base, const char *name, void (*func)());
 
 class TestBase {};
 

--- a/test/threads.ut.cc
+++ b/test/threads.ut.cc
@@ -8,25 +8,31 @@ using namespace handy;
 TEST(test::TestBase, ThreadPool) {
     ThreadPool pool(2, 5, false);
     int processed = 0;
-    int* p = &processed;
+    int *p = &processed;
     int added = 0;
-    for (int i = 0; i < 10; i ++) {
-        added += pool.addTask([=]{ printf("task %d processed\n", i);++*p; });
+    for (int i = 0; i < 10; i++) {
+        added += pool.addTask([=] {
+            printf("task %d processed\n", i);
+            ++*p;
+        });
     }
     pool.start();
-    usleep(100*1000);
+    usleep(100 * 1000);
     pool.exit();
     pool.join();
     ASSERT_EQ(added, processed);
     printf("pool tested\n");
     ThreadPool pool2(2);
-    usleep(100*1000);
+    usleep(100 * 1000);
     processed = 0;
     added = 0;
-    for (int i = 0; i < 10; i ++) {
-        added += pool2.addTask([=]{ printf("task %d processed\n", i);++*p; });
+    for (int i = 0; i < 10; i++) {
+        added += pool2.addTask([=] {
+            printf("task %d processed\n", i);
+            ++*p;
+        });
     }
-    usleep(100*1000);
+    usleep(100 * 1000);
     pool2.exit();
     pool2.join();
     ASSERT_EQ(added, processed);
@@ -36,7 +42,7 @@ TEST(test::TestBase, SafeQueue) {
     SafeQueue<int> q;
     atomic<bool> exit(false);
     q.push(-1);
-    thread t([&]{ 
+    thread t([&] {
         while (!exit.load(memory_order_relaxed)) {
             int v = q.pop_wait(50);
             if (v) {
@@ -48,14 +54,13 @@ TEST(test::TestBase, SafeQueue) {
             }
         }
     });
-    usleep(300*1000);
+    usleep(300 * 1000);
     printf("push other values\n");
     for (int i = 0; i < 5; i++) {
-        q.push(i+1);
+        q.push(i + 1);
     }
-    usleep(300*1000);
+    usleep(300 * 1000);
     exit.store(true, memory_order_relaxed);
     t.join();
     ASSERT_EQ(q.size(), 0);
 }
-

--- a/test/ut.cc
+++ b/test/ut.cc
@@ -1,9 +1,9 @@
 #include <handy/logging.h>
 #include "test_harness.h"
 
-int main(int argc, char** argv) {
+int main(int argc, char **argv) {
     char junk = 0;
-    for (int i = 1; i < argc; i ++) {
+    for (int i = 1; i < argc; i++) {
         if (sscanf(argv[i], "-%c", &junk) == 1) {
             if (junk == 'h') {
                 printf("%s [options] [matcher]\n", argv[0]);

--- a/test/util.ut.cc
+++ b/test/util.ut.cc
@@ -7,7 +7,7 @@ using namespace handy;
 TEST(test::TestBase, static_func) {
     ASSERT_EQ("a", util::format("a"));
     string s1 = "hello";
-    for (int i = 0; i < 999; i ++) {
+    for (int i = 0; i < 999; i++) {
         s1 += "hello";
     }
     string s2 = util::format("%s", s1.c_str());


### PR DESCRIPTION
In this PR, I added clang-format into CI to check our cpp code style.
If the code style doesn't be passed, the CI will show failure message.
And also we can take a look at the CI log to check the details of code style issue.

What's the changes?

Add clang-format tool configure in CI.
Format code with clang-format.
I am sorry that this PR is too large, but there is no more way about it, because we after enabling it in CI, the code will not be passed, and we should format the code at the same time.