### PR TITLE
Minor CMake Cleanups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(handy)
 
 set(CMAKE_CXX_STANDARD 11)
 
+include(GNUInstallDirs)
+
 find_package(Threads REQUIRED)
 
 list(APPEND HANDY_SRCS
@@ -39,6 +41,7 @@ if(BUILD_HANDY_SHARED_LIBRARY)
     add_library(handy SHARED ${HANDY_SRCS})
     target_include_directories(handy PUBLIC ${PROJECT_SOURCE_DIR}/handy)
     target_link_libraries(handy Threads::Threads)
+    install(TARGETS handy DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif(BUILD_HANDY_SHARED_LIBRARY)
 
 #Handy Static library
@@ -46,13 +49,39 @@ if(BUILD_HANDY_STATIC_LIBRARY)
     add_library(handy_s STATIC ${HANDY_SRCS})
     target_include_directories(handy_s PUBLIC ${PROJECT_SOURCE_DIR}/handy/)
     target_link_libraries(handy_s Threads::Threads)
+    install(TARGETS handy_s DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif(BUILD_HANDY_STATIC_LIBRARY)
+
+if(BUILD_HANDY_SHARED_LIBRARY OR BUILD_HANDY_STATIC_LIBRARY)
+    install(FILES 
+        ${PROJECT_SOURCE_DIR}/handy/codec.h
+        ${PROJECT_SOURCE_DIR}/handy/conf.h
+        ${PROJECT_SOURCE_DIR}/handy/conn.h
+        ${PROJECT_SOURCE_DIR}/handy/daemon.h
+        ${PROJECT_SOURCE_DIR}/handy/event_base.h
+        ${PROJECT_SOURCE_DIR}/handy/file.h
+        ${PROJECT_SOURCE_DIR}/handy/handy.h
+        ${PROJECT_SOURCE_DIR}/handy/handy-imp.h
+        ${PROJECT_SOURCE_DIR}/handy/http.h
+        ${PROJECT_SOURCE_DIR}/handy/logging.h
+        ${PROJECT_SOURCE_DIR}/handy/net.h
+        ${PROJECT_SOURCE_DIR}/handy/poller.h
+        ${PROJECT_SOURCE_DIR}/handy/port_posix.h
+        ${PROJECT_SOURCE_DIR}/handy/slice.h
+        ${PROJECT_SOURCE_DIR}/handy/stat-svr.h
+        ${PROJECT_SOURCE_DIR}/handy/status.h
+        ${PROJECT_SOURCE_DIR}/handy/threads.h
+        ${PROJECT_SOURCE_DIR}/handy/udp.h
+        ${PROJECT_SOURCE_DIR}/handy/util.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/handy)
+endif(BUILD_HANDY_SHARED_LIBRARY OR BUILD_HANDY_STATIC_LIBRARY)
 
 
 function(add_handy_executable EXECUTABLE_NAME EXECUTABLE_SOURCES)
     add_executable(${EXECUTABLE_NAME} ${EXECUTABLE_SOURCES})
     target_link_libraries(${EXECUTABLE_NAME} handy_s)
     target_include_directories(${EXECUTABLE_NAME} PUBLIC ${PROJECT_SOURCE_DIR})
+    install(TARGETS ${EXECUTABLE_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 endfunction(add_handy_executable)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,83 +1,81 @@
 cmake_minimum_required(VERSION 3.9)
-add_definitions(-DOS_MACOSX)
-project(echo)
+project(handy)
 
-include_directories("${PROJECT_SOURCE_DIR}")
 set(CMAKE_CXX_STANDARD 11)
 
-aux_source_directory(handy HANDY_SRCS)
-add_library(handy
-        ${HANDY_SRCS})
+find_package(Threads REQUIRED)
 
-add_executable(codec-cli
-        examples/codec-cli.cc)
-target_link_libraries(codec-cli handy)
+list(APPEND HANDY_SRCS
+    ${PROJECT_SOURCE_DIR}/handy/daemon.cc
+    ${PROJECT_SOURCE_DIR}/handy/net.cc
+    ${PROJECT_SOURCE_DIR}/handy/codec.cc
+    ${PROJECT_SOURCE_DIR}/handy/http.cc
+    ${PROJECT_SOURCE_DIR}/handy/conn.cc
+    ${PROJECT_SOURCE_DIR}/handy/poller.cc
+    ${PROJECT_SOURCE_DIR}/handy/udp.cc
+    ${PROJECT_SOURCE_DIR}/handy/threads.cc
+    ${PROJECT_SOURCE_DIR}/handy/file.cc
+    ${PROJECT_SOURCE_DIR}/handy/util.cc
+    ${PROJECT_SOURCE_DIR}/handy/conf.cc
+    ${PROJECT_SOURCE_DIR}/handy/stat-svr.cc
+    ${PROJECT_SOURCE_DIR}/handy/port_posix.cc
+    ${PROJECT_SOURCE_DIR}/handy/event_base.cc
+    ${PROJECT_SOURCE_DIR}/handy/logging.cc)
 
-add_executable(codec-svr
-        examples/codec-svr.cc)
-target_link_libraries(codec-svr handy)
+if(CMAKE_HOST_APPLE)
+    add_definitions(-DOS_MACOSX)
+elseif(CMAKE_HOST_UNIX)
+    add_definitions(-DOS_LINUX)
+else(CMAKE_HOST_APPLE)
+    message(FATAL_ERROR "Platform not supported")
+endif(CMAKE_HOST_APPLE)
 
-add_executable(daemon
-        examples/daemon.cc)
-target_link_libraries(daemon handy)
+option(BUILD_HANDY_SHARED_LIBRARY "Build Handy Shared Library" OFF)
+option(BUILD_HANDY_STATIC_LIBRARY "Build Handy Shared Library" ON)
+option(BUILD_HANDY_EXAMPLES "Build Handy Examples" OFF)
 
-add_executable(echo
-        examples/echo.cc)
-target_link_libraries(echo handy)
+##Handy Shared Library
+if(BUILD_HANDY_SHARED_LIBRARY)
+    add_library(handy ${HANDY_SRCS})
+    target_include_directories(handy PUBLIC ${PROJECT_SOURCE_DIR}/handy)
+    target_link_libraries(handy Threads::Threads)
+endif(BUILD_HANDY_SHARED_LIBRARY)
 
-add_executable(hsha
-        examples/hsha.cc)
-target_link_libraries(hsha handy)
+#Handy Static library
+if(BUILD_HANDY_STATIC_LIBRARY)
+    add_library(handy_s STATIC ${HANDY_SRCS})
+    target_include_directories(handy_s PUBLIC ${PROJECT_SOURCE_DIR}/handy/)
+    target_link_libraries(handy_s Threads::Threads)
+endif(BUILD_HANDY_STATIC_LIBRARY)
 
-add_executable(http-hello
-        examples/http-hello.cc)
-target_link_libraries(http-hello handy)
 
-add_executable(idle-close
-        examples/idle-close.cc)
-target_link_libraries(idle-close handy)
+function(add_handy_executable EXECUTABLE_NAME EXECUTABLE_SOURCES)
+    add_executable(${EXECUTABLE_NAME} ${EXECUTABLE_SOURCES})
+    target_link_libraries(${EXECUTABLE_NAME} handy_s)
+    target_include_directories(${EXECUTABLE_NAME} PUBLIC ${PROJECT_SOURCE_DIR})
+endfunction(add_handy_executable)
 
-add_executable(reconnect
-        examples/reconnect.cc)
-target_link_libraries(reconnect handy)
 
-add_executable(safe-close
-        examples/safe-close.cc)
-target_link_libraries(safe-close handy)
+if(BUILD_HANDY_EXAMPLES)
+    add_handy_executable(codec-cli examples/codec-cli.cc)
+    add_handy_executable(codec-svr examples/codec-svr.cc)
+    add_handy_executable(daemon examples/daemon.cc)
+    add_handy_executable(echo examples/echo.cc)
+    add_handy_executable(hsha examples/hsha.cc)
+    add_handy_executable(http-hello examples/http-hello.cc)
+    add_handy_executable(idle-close examples/idle-close.cc)
+    add_handy_executable(reconnect examples/reconnect.cc)
+    add_handy_executable(safe-close examples/safe-close.cc)
+    add_handy_executable(stat examples/stat.cc)
+    add_handy_executable(timer examples/timer.cc)
+    add_handy_executable(udp-cli examples/udp-cli.cc)
+    add_handy_executable(udp-hsha examples/udp-hsha.cc)
+    add_handy_executable(udp-svr examples/udp-svr.cc)
+    add_handy_executable(write-on-empty examples/write-on-empty.cc)
+    add_handy_executable(10m-cli 10m/10m-cli.cc)
+    add_handy_executable(10m-svr 10m/10m-svr.cc)
 
-add_executable(stat
-        examples/stat.cc)
-target_link_libraries(stat handy)
-
-add_executable(timer
-        examples/timer.cc)
-target_link_libraries(timer handy)
-
-add_executable(udp-cli
-        examples/udp-cli.cc)
-target_link_libraries(udp-cli handy)
-
-add_executable(udp-hsha
-        examples/udp-hsha.cc)
-target_link_libraries(udp-hsha handy)
-
-add_executable(udp-svr
-        examples/udp-svr.cc)
-target_link_libraries(udp-svr handy)
-
-add_executable(write-on-empty
-        examples/write-on-empty.cc)
-target_link_libraries(write-on-empty handy)
-
-add_executable(10m-cli
-        10m/10m-cli.cc)
-target_link_libraries(10m-cli handy)
-
-add_executable(10m-svr
-        10m/10m-svr.cc)
-target_link_libraries(10m-svr handy)
-
-add_executable(kqueue
-        raw-examples/kqueue.cc)
-target_link_libraries(kqueue handy)
-
+    if(CMAKE_HOST_APPLE)
+        add_handy_executable(kqueue raw-examples/kqueue.cc)
+    endif(CMAKE_HOST_APPLE)
+endif(BUILD_HANDY_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ option(BUILD_HANDY_EXAMPLES "Build Handy Examples" OFF)
 
 ##Handy Shared Library
 if(BUILD_HANDY_SHARED_LIBRARY)
-    add_library(handy ${HANDY_SRCS})
+    add_library(handy SHARED ${HANDY_SRCS})
     target_include_directories(handy PUBLIC ${PROJECT_SOURCE_DIR}/handy)
     target_link_libraries(handy Threads::Threads)
 endif(BUILD_HANDY_SHARED_LIBRARY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.2)
 project(handy)
 
 set(CMAKE_CXX_STANDARD 11)

--- a/README-en.md
+++ b/README-en.md
@@ -22,10 +22,43 @@ can use valgrind to check memory leak
 *   use kqueue on MacOSX
 
 [performance report](http://www.oschina.net/p/c11-handy)
-
 ### elegant
 
 only 10 lines can finish a complete server
+
+## Usage
+### Build handy shared library and examples:
+```
+$ git clone https://github.com/yedf/handy
+$ cd handy && mkdir build && cd build
+$ cmake -DBUILD_HANDY_SHARED_LIBRARY=ON -DBUILD_HANDY_EXAMPLES=ON -DCMAKE_INSTALL_PREFIX=/tmp/handy ..
+$ make -j4 
+$ make install
+$ ls /tmp/handy
+bin  include  lib64
+$ ls /tmp/handy/bin/
+10m-cli  10m-svr  codec-cli  codec-svr  daemon  echo  hsha  http-hello  idle-close  reconnect  safe-close  stat  timer  udp-cli  udp-hsha  udp-svr  write-on-empty
+$ ls /tmp/handy/lib64/
+libhandy_s.a  libhandy.so
+```
+
+### As a static library in your own programs:
+* add handy as a git submodule to say a folder called vendor
+* in your CMakeLists.txt
+
+```
+add_subdirectory("vendor/handy" EXCLUDE_FROM_ALL)
+
+add_executable(${PROJECT_NAME} main.cpp)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+    "vendor/handy"
+)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+    handy_s
+)
+```
 
 ### sample --echo-server
 
@@ -59,10 +92,6 @@ ssl support files are in [handy-ssl](https://github.com/yedf/handy-ssl.git) beca
 ###protobuf supported
 
 examples can be found in directory protobuf
-
-###Installation
-
-    make && make install
 
 ###contents
 


### PR DESCRIPTION
Build both handy as both shared and static library.
Build the shared library and examples only optionally.

This way integration becomes easier with downstream projects:

add handy as a git submodule to say a folder called vendor
in your CMakeLists.txt
```
add_subdirectory("vendor/handy" EXCLUDE_FROM_ALL)

target_include_directories(${PROJECT_NAME} PUBLIC
    "vendor/handy"
)

target_link_libraries(${PROJECT_NAME} PUBLIC
    handy_s
)
```