### PR TITLE
rename PollerEpoll::fd_ to epfd_; rename PollerKqueue::fd_ to PollerK…

### DIFF
--- a/handy/poller.cc
+++ b/handy/poller.cc
@@ -18,7 +18,7 @@ namespace handy {
 #ifdef OS_LINUX
 
 struct PollerEpoll : public PollerBase {
-    int fd_;
+    int epfd_;
     std::set<Channel *> liveChannels_;
     // for epoll selected active events
     struct epoll_event activeEvs_[kMaxEvents];
@@ -35,18 +35,18 @@ PollerBase *createPoller() {
 }
 
 PollerEpoll::PollerEpoll() {
-    fd_ = epoll_create1(EPOLL_CLOEXEC);
-    fatalif(fd_ < 0, "epoll_create error %d %s", errno, strerror(errno));
-    info("poller epoll %d created", fd_);
+    epfd_ = epoll_create1(EPOLL_CLOEXEC);
+    fatalif(epfd_ < 0, "epoll_create error %d %s", errno, strerror(errno));
+    info("poller epoll %d created", epfd_);
 }
 
 PollerEpoll::~PollerEpoll() {
-    info("destroying poller %d", fd_);
+    info("destroying poller %d", epfd_);
     while (liveChannels_.size()) {
         (*liveChannels_.begin())->close();
     }
-    ::close(fd_);
-    info("poller %d destroyed", fd_);
+    ::close(epfd_);
+    info("poller %d destroyed", epfd_);
 }
 
 void PollerEpoll::addChannel(Channel *ch) {
@@ -54,8 +54,8 @@ void PollerEpoll::addChannel(Channel *ch) {
     memset(&ev, 0, sizeof(ev));
     ev.events = ch->events();
     ev.data.ptr = ch;
-    trace("adding channel %lld fd %d events %d epoll %d", (long long) ch->id(), ch->fd(), ev.events, fd_);
-    int r = epoll_ctl(fd_, EPOLL_CTL_ADD, ch->fd(), &ev);
+    trace("adding channel %lld fd %d events %d epoll %d", (long long) ch->id(), ch->fd(), ev.events, epfd_);
+    int r = epoll_ctl(epfd_, EPOLL_CTL_ADD, ch->fd(), &ev);
     fatalif(r, "epoll_ctl add failed %d %s", errno, strerror(errno));
     liveChannels_.insert(ch);
 }
@@ -65,13 +65,13 @@ void PollerEpoll::updateChannel(Channel *ch) {
     memset(&ev, 0, sizeof(ev));
     ev.events = ch->events();
     ev.data.ptr = ch;
-    trace("modifying channel %lld fd %d events read %d write %d epoll %d", (long long) ch->id(), ch->fd(), ev.events & POLLIN, ev.events & POLLOUT, fd_);
-    int r = epoll_ctl(fd_, EPOLL_CTL_MOD, ch->fd(), &ev);
+    trace("modifying channel %lld fd %d events read %d write %d epoll %d", (long long) ch->id(), ch->fd(), ev.events & POLLIN, ev.events & POLLOUT, epfd_);
+    int r = epoll_ctl(epfd_, EPOLL_CTL_MOD, ch->fd(), &ev);
     fatalif(r, "epoll_ctl mod failed %d %s", errno, strerror(errno));
 }
 
 void PollerEpoll::removeChannel(Channel *ch) {
-    trace("deleting channel %lld fd %d epoll %d", (long long) ch->id(), ch->fd(), fd_);
+    trace("deleting channel %lld fd %d epoll %d", (long long) ch->id(), ch->fd(), epfd_);
     liveChannels_.erase(ch);
     for (int i = lastActive_; i >= 0; i--) {
         if (ch == activeEvs_[i].data.ptr) {
@@ -83,7 +83,7 @@ void PollerEpoll::removeChannel(Channel *ch) {
 
 void PollerEpoll::loop_once(int waitMs) {
     int64_t ticks = util::timeMilli();
-    lastActive_ = epoll_wait(fd_, activeEvs_, kMaxEvents, waitMs);
+    lastActive_ = epoll_wait(epfd_, activeEvs_, kMaxEvents, waitMs);
     int64_t used = util::timeMilli() - ticks;
     trace("epoll wait %d return %d errno %d used %lld millsecond", waitMs, lastActive_, errno, (long long) used);
     fatalif(lastActive_ == -1 && errno != EINTR, "epoll return error %d %s", errno, strerror(errno));
@@ -108,7 +108,7 @@ void PollerEpoll::loop_once(int waitMs) {
 #elif defined(OS_MACOSX)
 
 struct PollerKqueue : public PollerBase {
-    int fd_;
+    int kqfd_;
     std::set<Channel *> liveChannels_;
     // for epoll selected active events
     struct kevent activeEvs_[kMaxEvents];
@@ -125,18 +125,18 @@ PollerBase *createPoller() {
 }
 
 PollerKqueue::PollerKqueue() {
-    fd_ = kqueue();
-    fatalif(fd_ < 0, "kqueue error %d %s", errno, strerror(errno));
-    info("poller kqueue %d created", fd_);
+    kqfd_ = kqueue();
+    fatalif(kqfd_ < 0, "kqueue error %d %s", errno, strerror(errno));
+    info("poller kqueue %d created", kqfd_);
 }
 
 PollerKqueue::~PollerKqueue() {
-    info("destroying poller %d", fd_);
+    info("destroying poller %d", kqfd_);
     while (liveChannels_.size()) {
         (*liveChannels_.begin())->close();
     }
-    ::close(fd_);
-    info("poller %d destroyed", fd_);
+    ::close(kqfd_);
+    info("poller %d destroyed", kqfd_);
 }
 
 void PollerKqueue::addChannel(Channel *ch) {
@@ -152,7 +152,7 @@ void PollerKqueue::addChannel(Channel *ch) {
         EV_SET(&ev[n++], ch->fd(), EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, ch);
     }
     trace("adding channel %lld fd %d events read %d write %d  epoll %d", (long long) ch->id(), ch->fd(), ch->events() & POLLIN, ch->events() & POLLOUT, fd_);
-    int r = kevent(fd_, ev, n, NULL, 0, &now);
+    int r = kevent(kqfd_, ev, n, NULL, 0, &now);
     fatalif(r, "kevent add failed %d %s", errno, strerror(errno));
     liveChannels_.insert(ch);
 }
@@ -174,12 +174,12 @@ void PollerKqueue::updateChannel(Channel *ch) {
         EV_SET(&ev[n++], ch->fd(), EVFILT_WRITE, EV_DELETE, 0, 0, ch);
     }
     trace("modifying channel %lld fd %d events read %d write %d epoll %d", (long long) ch->id(), ch->fd(), ch->events() & POLLIN, ch->events() & POLLOUT, fd_);
-    int r = kevent(fd_, ev, n, NULL, 0, &now);
+    int r = kevent(kqfd_, ev, n, NULL, 0, &now);
     fatalif(r, "kevent mod failed %d %s", errno, strerror(errno));
 }
 
 void PollerKqueue::removeChannel(Channel *ch) {
-    trace("deleting channel %lld fd %d epoll %d", (long long) ch->id(), ch->fd(), fd_);
+    trace("deleting channel %lld fd %d epoll %d", (long long) ch->id(), ch->fd(), kqfd_);
     liveChannels_.erase(ch);
     // remove channel if in ready stat
     for (int i = lastActive_; i >= 0; i--) {
@@ -195,7 +195,7 @@ void PollerKqueue::loop_once(int waitMs) {
     timeout.tv_sec = waitMs / 1000;
     timeout.tv_nsec = (waitMs % 1000) * 1000 * 1000;
     long ticks = util::timeMilli();
-    lastActive_ = kevent(fd_, NULL, 0, activeEvs_, kMaxEvents, &timeout);
+    lastActive_ = kevent(kqfd_, NULL, 0, activeEvs_, kMaxEvents, &timeout);
     trace("kevent wait %d return %d errno %d used %lld millsecond", waitMs, lastActive_, errno, util::timeMilli() - ticks);
     fatalif(lastActive_ == -1 && errno != EINTR, "kevent return error %d %s", errno, strerror(errno));
     while (--lastActive_ >= 0) {


### PR DESCRIPTION
"epfd_" and "kqfd_" are more intuitive and distinguishable from Channel::fd_