### PR TITLE
uri尾端?处理不正确

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ else(CMAKE_HOST_APPLE)
     message(FATAL_ERROR "Platform not supported")
 endif(CMAKE_HOST_APPLE)
 
-option(BUILD_HANDY_SHARED_LIBRARY "Build Handy Shared Library" OFF)
+option(BUILD_HANDY_SHARED_LIBRARY "Build Handy Shared Library" ON)
 option(BUILD_HANDY_STATIC_LIBRARY "Build Handy Shared Library" ON)
 option(BUILD_HANDY_EXAMPLES "Build Handy Examples" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ else(CMAKE_HOST_APPLE)
     message(FATAL_ERROR "Platform not supported")
 endif(CMAKE_HOST_APPLE)
 
-option(BUILD_HANDY_SHARED_LIBRARY "Build Handy Shared Library" ON)
+option(BUILD_HANDY_SHARED_LIBRARY "Build Handy Shared Library" OFF)
 option(BUILD_HANDY_STATIC_LIBRARY "Build Handy Shared Library" ON)
 option(BUILD_HANDY_EXAMPLES "Build Handy Examples" OFF)
 

--- a/handy/http.cc
+++ b/handy/http.cc
@@ -128,7 +128,7 @@ HttpMsg::Result HttpRequest::tryDecode(Slice buf, bool copyBody) {
                 }
                 break;
             }
-            if (i == query_uri.size()) {
+            if (i == query_uri.size() - 1) {
                 uri = query_uri;
             }
         }


### PR DESCRIPTION
复现用：
https://gist.github.com/skywalkerytx/fd7e773d434489fef37f42e690a6c101

复现用curl:

`curl -X POST 'http://127.0.0.1:8281/eval'`

在旧版中会拿到404，必须是`curl -X POST 'http://127.0.0.1:8281/eval?'` 才能成功


